### PR TITLE
docs: add guide for fixing rejected git push errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Start with one of these:
 - Add a common Git/GitHub error and its fix.
 - Add your contributor card in `contributors/`.
 - Answer a beginner question in Discussions.
+- Learn how to fix a rejected push: [GIT_PUSH_REJECTED.md](docs/GIT_PUSH_REJECTED.md)
 
 Good first issues are listed here:
 [good first issue](https://github.com/P-r-e-m-i-u-m/open-source-starter-lab/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)

--- a/docs/GIT_PUSH_REJECTED.md
+++ b/docs/GIT_PUSH_REJECTED.md
@@ -1,0 +1,46 @@
+# Fixing "Updates Were Rejected" Git Push Errors
+
+## Why does this happen?
+
+When you see this error:
+
+```
+error: failed to push some refs to 'origin'
+hint: Updates were rejected because the remote contains work that you do not have locally.
+```
+
+It means the remote branch (on GitHub) has commits that your local branch does not have yet. Git refuses to push so you do not accidentally overwrite someone else's work.
+
+## The safe fix — rebase
+
+Run these commands one at a time:
+
+```
+git pull --rebase origin main
+```
+
+Then push again:
+
+```
+git push origin your-branch-name
+```
+
+## What does `--rebase` do?
+
+Instead of creating a messy merge commit, rebase replays your local commits on top of the latest remote commits. Your history stays clean and linear.
+
+## ⚠️ Warning — commands to avoid
+
+Do not run this unless you fully understand what it does:
+
+```
+git push --force
+```
+
+Force pushing rewrites remote history and can permanently delete other people's commits. When in doubt, use `--rebase` instead.
+
+## Still stuck?
+
+- Run `git status` to see the current state of your branch.
+- Run `git log --oneline -5` to see your last 5 commits.
+- Ask for help in Discussions before using any destructive command.


### PR DESCRIPTION
Closes #15

## What changed
- Added `docs/GIT_PUSH_REJECTED.md` explaining why `Updates were rejected` happens and how to fix it safely
- Linked the guide from README under "Best First Contributions"

## Checklist
- [x] Explains the error in beginner-friendly language
- [x] Includes `git pull --rebase origin main` as a fix
- [x] Warns against using destructive commands blindly
- [x] Linked from README