### PR TITLE
docs: delete "first" so python wording consistent with rest of list

### DIFF
--- a/docs/SKILL_BASED_FIRST_ISSUES.md
+++ b/docs/SKILL_BASED_FIRST_ISSUES.md
@@ -22,7 +22,7 @@ Good for people who know JavaScript or want to start reading TypeScript.
 
 ## Python
 
-Good for people who know Python first and want to learn GitHub contribution workflow.
+Good for people who know Python and want to learn GitHub contribution workflow.
 
 - [Python beginner issues](https://github.com/P-r-e-m-i-u-m/open-source-starter-lab/issues?q=is%3Aissue+is%3Aopen+label%3A%22skill%3A+python%22)
 - Start with: docs that explain how Python learners can contribute to a TypeScript repo.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,18 +12,18 @@
         "oss-lab": "dist/src/cli.js"
       },
       "devDependencies": {
-        "@types/node": "^25.6.2",
+        "@types/node": "^25.8.0",
         "typescript": "^5.6.3"
       }
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/typescript": {
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Syed Abdul Aman",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^25.6.2",
+    "@types/node": "^25.8.0",
     "typescript": "^5.6.3"
   }
 }


### PR DESCRIPTION
## What changed?

- deleted the word **first** under python

## Why does this help?

- the wording for the list items is now consistent. Python was the only one that had the word first. 

BEFORE
> **JavaScript**
> Good for people who know JavaScript or want to start reading TypeScript.
> **Python**
> Good for people who know Python **first** and want to learn GitHub contribution workflow.

AFTER
> **JavaScript**
> Good for people who know JavaScript or want to start reading TypeScript.
> **Python**
> Good for people who know Python and want to learn GitHub contribution workflow.

## Testing

- [ X] I ran `npm run check`

` open-source-starter-lab % npm run check

> open-source-starter-lab@0.1.0 check
> npm run build && npm test && npm run demo
> open-source-starter-lab@0.1.0 build
> tsc -p tsconfig.json
> open-source-starter-lab@0.1.0 test
> npm run build && node dist/tests/smoke.test.js
> open-source-starter-lab@0.1.0 build
> tsc -p tsconfig.json

Smoke tests passed.

> open-source-starter-lab@0.1.0 demo
> npm run build && node dist/src/cli.js check --profile beginner
> open-source-starter-lab@0.1.0 build
> tsc -p tsconfig.json
`

## Related issue

Closes # no related issues
