### PR TITLE
docs: add first PR mistakes guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Want an issue assigned? Comment in the weekly thread: [Get assigned your first i
 | I want to... | Start here |
 | --- | --- |
 | Make my first pull request | [First PR guide](docs/FIRST_PULL_REQUEST.md) |
+| Avoid common first PR mistakes | [First PR mistakes](docs/FIRST_PR_MISTAKES.md) |
 | Find a small task | [Good first issues](https://github.com/P-r-e-m-i-u-m/open-source-starter-lab/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) |
 | Choose the right first issue | [Choosing your first issue](docs/CHOOSING_FIRST_ISSUE.md) |
 | Find an issue by skill and time | [First Issue Fit Finder](docs/FIRST_ISSUE_FIT_FINDER.md) |

--- a/docs/FIRST_PR_MISTAKES.md
+++ b/docs/FIRST_PR_MISTAKES.md
@@ -1,0 +1,59 @@
+# Common First PR Mistakes
+
+Your first pull request does not need to be perfect. It should be small,
+clear, and easy for a maintainer to review.
+
+## 1. Changing too many things at once
+
+Mistake: You fix the issue, update unrelated wording, and reformat files in the
+same PR.
+
+Fix: Keep one PR focused on one issue. If you notice another improvement, write
+it down and open a separate issue or PR later.
+
+## 2. Not reading the issue carefully
+
+Mistake: You start coding before checking the goal, suggested files, and done
+criteria.
+
+Fix: Before editing, copy the "done when" list into your notes and check each
+item before opening the PR.
+
+## 3. Working on an issue that someone else already claimed
+
+Mistake: You make a PR without checking comments, assignments, or existing pull
+requests.
+
+Fix: Read the issue comments and open PRs first. If it is unclear, leave a short
+comment asking whether the issue is still available.
+
+## 4. Forgetting to test the change
+
+Mistake: You open the PR with no proof that the project still works.
+
+Fix: Run the project checks from the README or CONTRIBUTING guide. Add the exact
+command and result to your PR description.
+
+## 5. Using an unclear PR title or description
+
+Mistake: The PR says only "fix" or "update docs", so the maintainer has to guess
+what changed.
+
+Fix: Use a title that names the change, such as "Add first PR mistakes guide".
+In the description, include what changed, why it helps, and how you tested it.
+
+## 6. Taking review feedback personally
+
+Mistake: Review comments feel like criticism, so you stop responding or explain
+too much.
+
+Fix: Treat review as part of the workflow. Reply briefly, make the requested
+change, and ask a question if the feedback is unclear.
+
+## Quick checklist
+
+- Does the PR solve one clear issue?
+- Did you check comments and existing PRs first?
+- Did you only change the files needed for the issue?
+- Did you run the expected checks?
+- Does the PR description explain the change and the test result?


### PR DESCRIPTION
## Summary
- Add a beginner-friendly guide for common first PR mistakes.
- Link the guide from the README Pick Your Path table.

## Why
This helps beginners avoid common issues before opening their first pull request.

## Changes
- Added `docs/FIRST_PR_MISTAKES.md` with six mistakes and one practical fix for each.
- Added a README link to the new guide.

## Testing
- Ran `git diff --cached --check`
- Ran `npm ci`
- Ran `npm test`
- Result: `Smoke tests passed.`

## Known Issues
None.

Closes #4
