### PR TITLE
Add Windows Git setup guide

### DIFF
--- a/docs/WINDOWS_GIT_SETUP.md
+++ b/docs/WINDOWS_GIT_SETUP.md
@@ -1,0 +1,11 @@
+# Windows Git Setup
+
+## Install Git
+Download and install Git for Windows.
+
+## Check Git works
+
+Open PowerShell and run:
+```bash
+git --version
+```


### PR DESCRIPTION
What changed?
Added a Windows Git setup guide in docs/WINDOWS_GIT_SETUP.md.
The guide explains how to install Git on Windows and verify it using git --version.

Why does this help?
Makes it easier for new contributors on Windows to set up Git correctly.
Reduces setup confusion and improves onboarding for beginners.

Testing
I ran npm run check
Manually verified the markdown renders correctly in VS Code
Confirmed git --version works on my system

