### PR TITLE
Improve CLI output message for issue search URL

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,8 @@ function printIssueFit(): void {
   console.log(`Time: ${fit.timeBudget}`);
   console.log(`Why it fits: ${fit.whyItFits}`);
   console.log(`First command: ${fit.firstCommand}`);
-  console.log(`Issue search: ${fit.issueSearchUrl}`);
+  console.log("\nFind an issue to work on:");
+  console.log(`→ Copy this URL into your browser: ${fit.issueSearchUrl}`);
   console.log("\nProof checklist:");
   for (const item of fit.proofChecklist) {
     console.log(`- ${item}`);

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -22,6 +22,10 @@ assert.equal(docsFit.timeBudget, "30m");
 assert.ok(docsFit.issueSearchUrl.includes("no%3Aassignee"));
 assert.ok(docsFit.commentTemplate.includes("Please assign this to me"));
 
+// Test that the issue search URL is actionable
+assert.ok(docsFit.issueSearchUrl.startsWith("https://github.com"));
+assert.ok(docsFit.issueSearchUrl.includes("is%3Aopen")); // URL-encoded
+
 const jsFit = findIssueFit("ts", "1h");
 assert.equal(jsFit.skill, "javascript");
 assert.ok(jsFit.proofChecklist.some((item) => item.includes("full project check")));


### PR DESCRIPTION
## Summary
Make the CLI output more actionable when suggesting issue search URLs to users.

## Changes
- **cli.ts**: Improved the issue search output format with clearer heading and arrow indicator ("→ Copy this URL into your browser")
- **smoke.test.ts**: Added tests to verify the URL is valid

## Why
The previous message "Issue search: {url}" wasn't explicit enough about what users should do. Beginners might not realize they need to copy-paste the URL. The new format provides a clear call-to-action that guides them.

## Testing
✓ Build passes with `npm run build`  
✓ Tests pass  
✓ URL format verified