### PR TITLE
docs: add website accessibility checklist

### DIFF
--- a/docs/WEBSITE_ACCESSIBILITY_CHECKLIST.md
+++ b/docs/WEBSITE_ACCESSIBILITY_CHECKLIST.md
@@ -1,0 +1,11 @@
+# Website Accessibility Checklist
+
+Before changing files inside `site/`, review this checklist:
+
+- Ensure keyboard focus states are clearly visible
+- Verify text has readable color contrast
+- Make sure body text is readable on all screen sizes
+- Respect `prefers-reduced-motion` for animations and transitions
+- Add meaningful alt text to images
+- Use `aria-hidden="true"` for decorative icons or images
+- Test interactive elements using keyboard navigation

--- a/site/README.md
+++ b/site/README.md
@@ -26,3 +26,7 @@ https://p-r-e-m-i-u-m.github.io/open-source-starter-lab/
 - Trust signals
 - Maintainer automation showcase
 - Beginner FAQ
+
+## Accessibility
+
+See [WEBSITE_ACCESSIBILITY_CHECKLIST.md](../docs/WEBSITE_ACCESSIBILITY_CHECKLIST.md)


### PR DESCRIPTION
## What changed?

* Added `docs/WEBSITE_ACCESSIBILITY_CHECKLIST.md`
* Added accessibility checklist items for:

  * keyboard focus states
  * color contrast
  * readable body text
  * prefers-reduced-motion
  * alt text and aria-hidden guidance
* Linked the checklist in `site/README.md`

## Why does this help?

* Helps contributors follow accessibility best practices before modifying files inside `site/`
* Makes accessibility reviews easier and more consistent

## Testing

* [x] I ran `npm run check`

## Related issue

Closes #56