### PR TITLE
feat: add JSON output for issue ideas

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -26,6 +26,12 @@ node dist/src/cli.js issues
 
 This prints issue ideas with labels, difficulty, goals, and acceptance criteria.
 
+Pass `--json` to print the same ideas as pretty JSON for automation (each entry has `title`, `label`, `difficulty`, `goal`, and `acceptanceCriteria`):
+
+```bash
+node dist/src/cli.js issues --json
+```
+
 ## First Issue Fit Finder
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,18 @@ function printChecklist(profile: StarterProfile): void {
 }
 
 function printIssueIdeas(): void {
+  if (process.argv.includes("--json")) {
+    const payload = issueIdeas.map((idea) => ({
+      title: idea.title,
+      label: idea.label,
+      difficulty: idea.difficulty,
+      goal: idea.goal,
+      acceptanceCriteria: idea.acceptanceCriteria
+    }));
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
   console.log("Starter issue ideas\n");
   for (const idea of issueIdeas) {
     console.log(`- ${idea.title} [${idea.label}, ${idea.difficulty}]`);
@@ -107,6 +119,7 @@ function main(): void {
     console.log("  oss-lab check --profile beginner");
     console.log("  oss-lab check --profile maintainer");
     console.log("  oss-lab issues");
+    console.log("  oss-lab issues --json");
     console.log("  oss-lab fit --skill docs --time 30m");
     console.log("  oss-lab next --level second-pr");
     return;

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
 import { buildChecklist } from "../src/checklist.js";
 import { findIssueFit } from "../src/issueFitFinder.js";
 import { issueIdeas } from "../src/issueIdeas.js";
@@ -37,5 +39,19 @@ assert.equal(normalizeContributorLevel("second pr"), "second-pr");
 const maintainerShadow = getProgressionStep("maintainer-shadow");
 assert.ok(maintainerShadow.labels.includes("level: maintainer-practice"));
 assert.ok(maintainerShadow.proof.some((item) => item.includes("before/after")));
+
+const cliPath = path.resolve("dist/src/cli.js");
+const jsonOutput = execFileSync("node", [cliPath, "issues", "--json"], { encoding: "utf8" });
+const parsedIssues = JSON.parse(jsonOutput);
+assert.ok(Array.isArray(parsedIssues));
+assert.equal(parsedIssues.length, issueIdeas.length);
+for (const idea of parsedIssues) {
+  assert.equal(typeof idea.title, "string");
+  assert.equal(typeof idea.label, "string");
+  assert.equal(typeof idea.difficulty, "string");
+  assert.equal(typeof idea.goal, "string");
+  assert.ok(Array.isArray(idea.acceptanceCriteria));
+  assert.ok(idea.acceptanceCriteria.length >= 3);
+}
 
 console.log("Smoke tests passed.");


### PR DESCRIPTION
## Summary

Adds a JSON mode for starter issue ideas so the CLI can be used from scripts and demos without parsing the human-readable output.

`node dist/src/cli.js issues` still prints the existing text format. `node dist/src/cli.js issues --json` now emits pretty JSON with `title`, `label`, `difficulty`, `goal`, and `acceptanceCriteria` for each issue idea.

I also added a smoke assertion that runs the built CLI, parses the JSON output, and checks the emitted shape, plus documented the new flag in `docs/CLI.md`.

Closes #21.

## Verification

- `git diff --check`
- `npm test`
- `npm run check`
- `node dist/src/cli.js issues`
- `node dist/src/cli.js issues --json | python3 -m json.tool`
