### PR TITLE
Add first-time contributor FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Join the first cohort: [First PR Cohort 01 - Get your Open Source Trust Passport
 | --- | --- |
 | Make my first pull request | [First PR guide](docs/FIRST_PULL_REQUEST.md) |
 | Avoid common first PR mistakes | [First PR mistakes](docs/FIRST_PR_MISTAKES.md) |
+Read common first-time contributor questions [First-time contributor FAQ](docs/FIRST_TIME_CONTRIBUTOR_FAQ.md)
 | Understand common open-source words | [Contribution glossary](docs/GLOSSARY.md) |
 | Find a small task | [Good first issues](https://github.com/P-r-e-m-i-u-m/open-source-starter-lab/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) |
 | Find a curated first task | [Featured first issues](docs/FEATURED_FIRST_ISSUES.md) |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Join the first cohort: [First PR Cohort 01 - Get your Open Source Trust Passport
 | --- | --- |
 | Make my first pull request | [First PR guide](docs/FIRST_PULL_REQUEST.md) |
 | Avoid common first PR mistakes | [First PR mistakes](docs/FIRST_PR_MISTAKES.md) |
-Read common first-time contributor questions [First-time contributor FAQ](docs/FIRST_TIME_CONTRIBUTOR_FAQ.md)
+| Read common first-time contributor questions | [First-Time Contributor FAQ](docs/FIRST_TIME_CONTRIBUTOR_FAQ.md) |
 | Understand common open-source words | [Contribution glossary](docs/GLOSSARY.md) |
 | Find a small task | [Good first issues](https://github.com/P-r-e-m-i-u-m/open-source-starter-lab/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) |
 | Find a curated first task | [Featured first issues](docs/FEATURED_FIRST_ISSUES.md) |

--- a/docs/FIRST_TIME_CONTRIBUTOR_FAQ.md
+++ b/docs/FIRST_TIME_CONTRIBUTOR_FAQ.md
@@ -1,0 +1,37 @@
+# First-Time Contributor FAQ
+
+## Do I need permission before working on an issue?
+
+If the issue is labeled as a good first issue, you can usually start by leaving a short comment saying you would like to work on it. This helps avoid duplicate work.
+
+## What should I do if someone is already assigned?
+
+Choose a different issue unless the maintainer says help is still welcome. Assigned issues usually mean someone else is already working on the task.
+
+## What should I write in my pull request?
+
+Write what you changed, why it helps, and how you checked it. Keep it short and clear.
+
+## Do I need to run tests?
+
+If the project has tests or check commands, run them before opening the pull request. If you only changed documentation, say that no code tests were needed.
+
+## What if I make a mistake?
+
+Mistakes are normal in open source. You can update your branch, push another commit, or ask the maintainer what to fix.
+
+## What happens after I open a pull request?
+
+A maintainer or reviewer may leave comments, request changes, or merge it. Review comments are part of the process, not a failure.
+
+## How should I respond to review comments?
+
+Reply politely, make the requested changes, and push the updates to the same branch. The pull request will update automatically.
+
+## Can I ask questions if I am confused?
+
+Yes. Ask a specific question and include what you tried, what happened, and what you expected. Clear questions are easier to answer.
+
+## Should my first pull request be big?
+
+No. A small, focused pull request is better for a first contribution. It is easier to review and easier to merge.


### PR DESCRIPTION
This PR adds a first-time contributor FAQ.

It includes short answers about assignment, tests, reviews, mistakes, asking questions, and keeping a first pull request focused. It also links the FAQ from the README.

Closes #66.
