### PR TITLE
test: add unknown command CLI test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pr:welcome": "npm run build && node dist/scripts/welcomePullRequest.js",
     "pr:welcome:dry-run": "npm run build && node dist/scripts/welcomePullRequest.js --dry-run",
     "automation:health": "npm run build && node dist/scripts/createDailyIssue.js --dry-run && node dist/scripts/createWeeklyHelpDiscussion.js --dry-run && node dist/scripts/replyToAssignmentRequest.js --dry-run && node dist/scripts/welcomePullRequest.js --dry-run && node dist/scripts/afterMergeContributorProof.js --dry-run && node dist/scripts/generateMaintainerDashboard.js --dry-run",
-    "test": "npm run build && node dist/tests/smoke.test.js",
+    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js",
     "check": "npm run build && npm test && npm run demo"
   },
   "keywords": [

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,21 @@
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync(
+  process.execPath,
+  ['dist/src/cli.js', 'unknown-command'],
+  {
+    encoding: 'utf8'
+  }
+);
+
+if (result.status === 0) {
+  throw new Error('Expected unknown command to exit with a non-zero status code.');
+}
+
+const output = `${result.stdout}${result.stderr}`;
+
+if (!output.includes('Unknown command')) {
+  throw new Error('Expected output to include "Unknown command".');
+}
+
+console.log('Unknown command CLI test passed.');


### PR DESCRIPTION
## What changed?

- Added a new `tests/cli.test.ts` file.
- Updated the `test` script in `package.json` so the new CLI test runs after the existing smoke test.
- The new test runs the built CLI with an unknown command.
- It checks that the command exits with a non-zero status code.
- It checks that the output includes `Unknown command`.

## Why does this help?

-This adds test coverage for the existing unknown-command CLI behavior. The CLI already rejects invalid commands, but this PR verifies that behavior so future changes do not accidentally break it.

## Testing

- [ x ] I ran `npm run check`

Check output included:

```text
Smoke tests passed.
Unknown command CLI test passed.

## Related issue

Closes #22
