### PR TITLE
test: add unknown command CLI test

### DIFF
--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -57,4 +57,22 @@ for (const idea of parsedIssues) {
   assert.ok(idea.acceptanceCriteria.length >= 3);
 }
 
+let unknownCommandOutput = "";
+
+try {
+  execFileSync("node", [cliPath, "not-a-real-command"], {
+    encoding: "utf8",
+    stdio: "pipe"
+  });
+
+  assert.fail("Unknown command should fail");
+} catch (error) {
+  unknownCommandOutput = String(error);
+}
+
+assert.ok(
+  unknownCommandOutput.includes("Unknown command"),
+  "Expected output to include 'Unknown command'"
+);
+
 console.log("Smoke tests passed.");


### PR DESCRIPTION
## Summary

Adds a focused smoke test for unknown CLI commands.

The new test:

* Runs the CLI with an invalid command
* Verifies the command exits unsuccessfully
* Verifies the output includes "Unknown command"

This helps ensure future changes do not accidentally break the existing error handling behavior.

Closes #70


## Testing

Ran:

```bash
npm run check
```

Result:

* Build passed
* Smoke tests passed
* Demo command completed successfully

## Evidence

Screenshots attached:

* New smoke test implementation
* Successful `npm run check` output
<img width="1104" height="1461" alt="Screenshot 2026-06-03 131123" src="https://github.com/user-attachments/assets/696a77c5-8dbe-4224-b252-2a7c6d1b6a53" />
<img width="2991" height="2126" alt="Screenshot 2026-06-03 131418" src="https://github.com/user-attachments/assets/9474c38c-ec7f-4169-af33-79a8335e809d" />
