### PR TITLE
tooling: add site link checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/src/cli.js",
     "demo": "npm run build && node dist/src/cli.js check --profile beginner",
+    "site:check-links": "npm run build && node dist/scripts/checkSiteLinks.js",
     "issue:daily": "npm run build && node dist/scripts/createDailyIssue.js --dry-run",
     "issue:create": "npm run build && node dist/scripts/createDailyIssue.js",
     "issue:assignment-helper": "npm run build && node dist/scripts/replyToAssignmentRequest.js",

--- a/scripts/checkSiteLinks.ts
+++ b/scripts/checkSiteLinks.ts
@@ -1,0 +1,53 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const siteFilePath = path.join(process.cwd(), 'site', 'index.html');
+const siteDirectory = path.dirname(siteFilePath);
+
+const html = readFileSync(siteFilePath, 'utf8');
+
+const linkPattern = /(?:href|src)="([^"]+)"/g;
+
+const ignoredPrefixes = [
+  'http://',
+  'https://',
+  '#',
+  'mailto:',
+  'tel:'
+];
+
+const missingLinks: string[] = [];
+
+let match: RegExpExecArray | null;
+
+while ((match = linkPattern.exec(html)) !== null) {
+  const link = match[1];
+
+  if (ignoredPrefixes.some((prefix) => link.startsWith(prefix))) {
+    continue;
+  }
+
+  const cleanLink = link.split('#')[0].split('?')[0];
+
+  if (!cleanLink) {
+    continue;
+  }
+
+  const targetPath = path.join(siteDirectory, cleanLink);
+
+  if (!existsSync(targetPath)) {
+    missingLinks.push(link);
+  }
+}
+
+if (missingLinks.length > 0) {
+  console.error('Missing local site links found:');
+
+  missingLinks.forEach((link) => {
+    console.error(`- ${link}`);
+  });
+
+  process.exit(1);
+}
+
+console.log('Site link check passed.');


### PR DESCRIPTION
## What changed?
- Added `scripts/checkSiteLinks.ts`
- Added a `site:check-links` npm script
- The script reads `site/index.html`
- It checks local `href` and `src` references
- It ignores external links, hash links, mail links, and phone links
- It reports missing local site links with a clear error message

## Why does this help?

-This adds a lightweight local link checker for the website. It helps catch broken local references such as missing CSS, JavaScript, or local documentation files before they quietly affect the site.

## Testing

- [x] I ran `npm run site:check-links`
- [x] I ran `npm run check`

Check output included:

```text
Site link check passed.
Smoke tests passed.
Unknown command CLI test passed.

## Related issue

Closes # 57
