### PR TITLE
docs: add discussion answer examples

### DIFF
--- a/docs/DISCUSSION_ANSWER_EXAMPLES.md
+++ b/docs/DISCUSSION_ANSWER_EXAMPLES.md
@@ -1,0 +1,67 @@
+# Discussion Answer Examples
+
+## Example 1: Git Clone Error
+
+### Weak Answer
+
+Run git clone again.
+
+### Strong Answer
+
+Can you share the exact error message you received?
+
+If the repository is private, make sure you are signed in to GitHub and have permission to access it.
+
+Try:
+
+git clone <repository-url>
+
+If the error continues, paste the full output so the community can help diagnose the problem.
+
+Why this is better:
+
+* Asks for clarification
+* Provides a safe command
+* Explains the next step
+
+## Example 2: Build Failure
+
+### Weak Answer
+
+Your setup is wrong.
+
+### Strong Answer
+
+Could you tell us which operating system you are using and share the output from the build command?
+
+Try running:
+
+npm run check
+
+If the command fails, include the full error message. This helps others understand the environment and identify the root cause.
+
+Why this is better:
+
+* Avoids assumptions
+* Requests useful information
+* Gives a safe verification command
+
+## Example 3: First Contribution Question
+
+### Weak Answer
+
+Just pick any issue.
+
+### Strong Answer
+
+If you are new to the project, start with issues labeled "good first issue" or "help wanted."
+
+Before starting, read the contribution guide and comment on the issue to let maintainers know you would like to work on it.
+
+If you are unsure whether an issue matches your skill level, ask a clarifying question before beginning.
+
+Why this is better:
+
+* Gives actionable guidance
+* Encourages communication
+* Helps contributors choose appropriate work

--- a/docs/MAINTAINER_PLAYBOOK.md
+++ b/docs/MAINTAINER_PLAYBOOK.md
@@ -64,3 +64,7 @@ If you already cloned the repo, skip `git init`.
 ```
 
 Short can be good. Complete is better.
+
+## Discussion Answer Examples
+
+See [DISCUSSION_ANSWER_EXAMPLES.md](./DISCUSSION_ANSWER_EXAMPLES.md) for examples of weak and strong discussion answers, safe command usage, and situations where maintainers should ask clarifying questions before providing guidance.


### PR DESCRIPTION
## Summary

Adds examples of weak and strong GitHub Discussion answers.

Changes:

* Added three discussion Q&A examples
* Demonstrated safe command usage
* Added guidance on when to ask clarifying questions
* Linked the new guide from the maintainer playbook

Closes #68

## Testing

Ran:

npm run check

Result:

* Build passed
* Tests passed
* Demo completed successfully

## Evidence

Attached:

* Screenshot of DISCUSSION_ANSWER_EXAMPLES.md
* Screenshot showing successful npm run check output
<img width="3398" height="1832" alt="Screenshot 2026-06-05 202311" src="https://github.com/user-attachments/assets/cda990d8-6961-44c6-9cde-9e28dbed02be" />
<img width="3460" height="1614" alt="Screenshot 2026-06-05 202342" src="https://github.com/user-attachments/assets/96f7bdd4-a2b9-4ade-971a-694f1c985d82" />
