### PR TITLE
test: add invalid CLI profile coverage

### DIFF
--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -75,4 +75,22 @@ assert.ok(
   "Expected output to include 'Unknown command'"
 );
 
+let invalidProfileOutput = "";
+
+try {
+  execFileSync("node", [cliPath, "check", "--profile", "expert"], {
+    encoding: "utf8",
+    stdio: "pipe"
+  });
+
+  assert.fail("Invalid profile should fail");
+} catch (error) {
+  invalidProfileOutput = String(error);
+}
+
+assert.ok(
+  invalidProfileOutput.includes("Use --profile beginner or --profile maintainer"),
+  "Expected output to explain valid profile options"
+);
+
 console.log("Smoke tests passed.");


### PR DESCRIPTION
## What changed?
- Added smoke test coverage for invalid CLI profile input.
-  The test runs the built CLI with check --profile expert.
-  It verifies that invalid profile input fails.
-  It checks that the error message explains the valid options: beginner     and maintainer.


## Why does this help?
- This improves CLI input validation coverage. The CLI already only accepts beginner and maintainer checklist profiles, and this test helps make sure unsupported profile values do not silently pass in the future.

## Testing

- [ x ] I ran `npm run check`
- Check output included:

Smoke tests passed.
Unknown command CLI test passed.

## Related issue

Closes #6 
