### PR TITLE
feat: add profiles CLI command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,6 +87,12 @@ function printNextStep(): void {
   console.log(`\nNext move: ${step.nextMove}`);
 }
 
+function printProfiles(): void {
+  console.log("Available checklist profiles:");
+  console.log("- beginner: Use this profile when you are making a first or early open-source contribution.");
+  console.log("- maintainer: Use this profile when you are reviewing, organizing, or supporting contributor work.");
+}
+
 function main(): void {
   const command = process.argv[2] ?? "check";
 
@@ -114,12 +120,18 @@ function main(): void {
     return;
   }
 
+  if (command === "profiles") {
+    printProfiles();
+    return;
+  }  
+
   if (command === "help" || command === "--help" || command === "-h") {
     console.log("Usage:");
     console.log("  oss-lab check --profile beginner");
     console.log("  oss-lab check --profile maintainer");
     console.log("  oss-lab issues");
     console.log("  oss-lab issues --json");
+    console.log("  oss-lab profiles");
     console.log("  oss-lab fit --skill docs --time 30m");
     console.log("  oss-lab next --level second-pr");
     return;

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -57,6 +57,15 @@ for (const idea of parsedIssues) {
   assert.ok(idea.acceptanceCriteria.length >= 3);
 }
 
+const profilesOutput = execFileSync("node", [cliPath, "profiles"], {
+  encoding: "utf8"
+});
+
+assert.ok(profilesOutput.includes("beginner"));
+assert.ok(profilesOutput.includes("maintainer"));
+assert.ok(profilesOutput.includes("first or early open-source contribution"));
+assert.ok(profilesOutput.includes("reviewing, organizing, or supporting contributor work"));
+
 let unknownCommandOutput = "";
 
 try {


### PR DESCRIPTION
## What changed?

- Added a new `profiles` CLI command.
- The command lists the supported checklist profiles: `beginner` and `maintainer`.
- Added a short explanation for when each profile should be used.
- Added the command to the CLI help output.
- Added smoke test coverage for the new command.    

## Why does this help?

- This makes the available checklist profiles easier to discover without needing to read the source code or help text closely. It gives users a clear way to see which profiles are supported and when to use each one.


## Testing

- [x] I ran `npm run check`
- [x] I ran `node dist/src/cli.js profiles`
- [x] I ran `npm run check`

Check output included:

```text
Smoke tests passed.
Unknown command CLI test passed.

## Related issue

Closes #37 
