### PR TITLE
add bug reproduction guideDocs pr description guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,3 +46,17 @@ npm run check
 - Weekly help threads available.
 
 We're here to help you grow as a contributor and maintainer. Let's build something great together! 🌟
+
+
+## Pull Request Descriptions
+
+A helpful pull request description makes reviews faster and easier.
+
+When opening a pull request, please include:
+
+- A summary of your changes
+- The reason for the change
+- Testing evidence
+- Related issues using `Closes #issue-number`
+
+For examples and guidance, see the [PR Description Guide](docs/PR_DESCRIPTION_GUIDE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,9 @@ When opening a pull request, please include:
 - Related issues using `Closes #issue-number`
 
 For examples and guidance, see the [PR Description Guide](docs/PR_DESCRIPTION_GUIDE.md).
+
+## Reproducing Bugs
+
+Before working on a bug fix, make sure you can reproduce the issue locally. Clear reproduction steps help reviewers understand the problem and verify the fix.
+
+See [Bug Reproduction Guide](docs/BUG_REPRODUCTION_GUIDE.md).

--- a/docs/BUG_REPRODUCTION_GUIDE.md
+++ b/docs/BUG_REPRODUCTION_GUIDE.md
@@ -1,0 +1,87 @@
+# Bug Reproduction Guide
+
+Before opening a bug fix PR, make sure you can reproduce the problem yourself. Reproducing the issue helps reviewers understand the bug and makes it easier to verify that the fix works.
+
+## Describe the problem
+
+Include:
+
+* What actually happened
+* What you expected to happen
+* Any error messages you saw
+
+Example:
+
+**Actual behavior**
+
+The application crashes when clicking the Save button.
+
+**Expected behavior**
+
+The data should be saved and a success message should appear.
+
+## Reproduction Template
+
+Copy and fill out the following template:
+
+### Environment
+
+* Operating System:
+* Node.js version:
+* Project version:
+
+### Steps to Reproduce
+
+1. Run:
+
+   ```bash
+   npm install
+   npm start
+   ```
+
+2. Open the application.
+
+3. Navigate to ...
+
+4. Click ...
+
+5. Observe ...
+
+### Actual Result
+
+Describe what happened.
+
+### Expected Result
+
+Describe what should happen.
+
+## Include Useful Command Output
+
+When relevant, include:
+
+```bash
+npm run check
+npm test
+node --version
+```
+
+Paste the output directly into the issue or PR description.
+
+## Screenshots
+
+Screenshots are optional.
+
+Include them only when they make the problem easier to understand, such as:
+
+* Visual bugs
+* Layout issues
+* Incorrect UI states
+
+For non-visual bugs, reproduction steps and command output are usually more helpful.
+
+## Before Opening a Bug Fix PR
+
+* Confirm you can reproduce the issue.
+* Document the reproduction steps.
+* Verify your fix resolves the issue.
+* Run project checks before submitting.

--- a/docs/PR_DESCRIPTION_GUIDE.md
+++ b/docs/PR_DESCRIPTION_GUIDE.md
@@ -1,0 +1,75 @@
+# PR Description Guide
+
+Thank you for contributing!
+
+A clear pull request description helps maintainers understand your change, review it more quickly, and provide useful feedback. You do not need to write a long description, but a little context goes a long way.
+
+## What Makes a Helpful PR Description?
+
+Try to include:
+
+* What changed
+* Why the change was made
+* How you tested it
+* Any related issue numbers
+
+## Example: Not Helpful
+
+### Summary
+Fixed some documentation.
+
+### Testing
+Tested it.
+
+## Example: Helpful
+
+### Summary
+Adds a guide explaining how contributors can write useful pull request descriptions.
+
+### Why
+New contributors often open pull requests with very little context, which makes reviews slower and more difficult.
+
+### Testing
+
+* Ran `npm run check`
+* Verified documentation links work correctly
+* Confirmed no existing files were affected
+
+### Related Issue
+
+Closes #123
+
+## Testing Evidence
+
+Whenever possible, include evidence showing that your change works.
+
+Examples:
+
+* Output from `npm run check`
+* Screenshots of UI changes
+* Test results
+* Manual verification steps
+
+Even a short note about what you tested is helpful for reviewers.
+
+## Linking Issues
+
+If your pull request resolves an issue, link it using:
+
+```text
+Closes #issue-number
+```
+
+For example:
+
+```text
+Closes #44
+```
+
+GitHub will automatically link the issue and close it when the pull request is merged.
+
+## Final Tip
+
+A good pull request description does not need to be long. A few sentences explaining the change, the reason behind it, and how it was tested are usually enough.
+
+Thank you for helping improve the project!


### PR DESCRIPTION
## What changed?

- Added `docs/BUG_REPRODUCTION_GUIDE.md`
- Added a reproduction template
- Linked the guide from `CONTRIBUTING.md`

## Why does this help?

- Helps contributors reproduce bugs before submitting bug fix PRs.
- Makes issues easier to verify and review.

## Testing

- [x] I ran `npm run check`

### Check Output

```text
Smoke tests passed.
Unknown command CLI test passed.
```

## Related issue

Closes #24