### PR TITLE
docs: add bug reproduction guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,6 @@ When opening a pull request, please include:
 - Testing evidence
 - Related issues using `Closes #issue-number`
 
-For examples and guidance, see the [PR Description Guide](docs/PR_DESCRIPTION_GUIDE.md).
 
 ## Reproducing Bugs
 

--- a/docs/BUG_REPRODUCTION_GUIDE.md
+++ b/docs/BUG_REPRODUCTION_GUIDE.md
@@ -85,3 +85,5 @@ For non-visual bugs, reproduction steps and command output are usually more help
 * Document the reproduction steps.
 * Verify your fix resolves the issue.
 * Run project checks before submitting.
+
+


### PR DESCRIPTION
## What changed?

- Added a new Bug Reproduction Guide for contributors.
- Linked the guide from `CONTRIBUTING.md`.


## Why does this help?

- It helps contributors clearly explain actual behavior, expected behavior, reproduction steps, command output, and screenshots before opening a bug fix PR.
- This makes bug reports and PR reviews easier for maintainers to understand and verify.

## Testing

- [ x ] I ran `npm run check`

## Related issue

Closes #40 
