### PR TITLE
docs: add safe issue-to-pr workflow example

### DIFF
--- a/docs/FIRST_PULL_REQUEST.md
+++ b/docs/FIRST_PULL_REQUEST.md
@@ -73,7 +73,45 @@ A maintainer will review your PR. They might:
 - Be patient — maintainers are often volunteers
 
 ---
+## Safe Issue-to-PR Workflow Example
 
+Use this flow for small beginner-friendly issues, especially documentation changes.
+
+```bash
+git clone https://github.com/YOUR-USERNAME/REPO-NAME.git
+cd REPO-NAME
+git checkout -b docs/short-description
+git status
+```
+What each command does:
+
+- `git clone` downloads your fork to your computer.
+- `cd` moves you into the project folder.
+- `git checkout -b` creates a new branch for your work.
+- `git status` shows which files changed.
+
+After editing files:
+
+```bash
+git status
+git add PATH/TO/CHANGED_FILE.md
+git commit -m "docs: describe your change"
+git push origin docs/short-description
+```
+What each command does:
+
+- `git status` helps you review your changes before committing.
+- `git add` stages only the file you want to include in the pull request.
+- `git commit` saves your staged change locally with a short message.
+- `git push` sends your branch to GitHub so you can open a pull request.
+
+If a command fails, do not guess or run destructive commands. Copy the full error message and ask for help in the issue or pull request. Include:
+
+- the command you ran
+- what you expected to happen
+- what happened instead
+
+---
 ## Quick Reference
 
 ```bash


### PR DESCRIPTION
## What changed?

-Added a safe issue-to-PR workflow example to `docs/FIRST_PULL_REQUEST.md`.

The new section includes:

- a small command sequence for cloning a fork, creating a branch, checking status, committing, and pushing
- plain-language explanations for what each command does
- guidance on how to ask for help if a command fails

## Why does this help?

-This gives first-time contributors a simple, safe workflow they can follow when moving from an assigned issue to opening a pull request.
It also warns beginners not to guess or run destructive commands when something fails.

## Testing

- [ x ] I ran `npm run check`

## Related issue

Closes #33
