### PR TITLE
feat: add CLI fit help text

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,6 +133,8 @@ function main(): void {
     console.log("  oss-lab issues --json");
     console.log("  oss-lab profiles");
     console.log("  oss-lab fit --skill docs --time 30m");
+    console.log("    Skills: html-css, javascript, python, docs, testing, git");
+    console.log("    Time: 15m, 30m, 1h");
     console.log("  oss-lab next --level second-pr");
     return;
   }

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -66,6 +66,14 @@ assert.ok(profilesOutput.includes("maintainer"));
 assert.ok(profilesOutput.includes("first or early open-source contribution"));
 assert.ok(profilesOutput.includes("reviewing, organizing, or supporting contributor work"));
 
+const helpOutput = execFileSync("node", [cliPath, "help"], {
+  encoding: "utf8"
+});
+
+assert.ok(helpOutput.includes("oss-lab fit --skill docs --time 30m"));
+assert.ok(helpOutput.includes("Skills: html-css, javascript, python, docs, testing, git"));
+assert.ok(helpOutput.includes("Time: 15m, 30m, 1h"));
+
 let unknownCommandOutput = "";
 
 try {


### PR DESCRIPTION
## What changed

- Added accepted skill values to the `fit` CLI help output.
- Added supported time values: `15m`, `30m`, and `1h`.
- Added smoke test coverage for the new help output.

## Why

The `fit` command did not clearly show contributors which skill and time values were supported.

This makes the command easier for new contributors to discover and use.

## Testing

- `npm test`
- `npm run check`
- `git diff --check`

## Related issue

Closes #132