### PR TITLE
fix: improve navigation link accessibility

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -139,6 +139,13 @@ main {
   text-decoration: none;
 }
 
+.nav-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 4px 2px;
+}
+
 .nav-links a:hover,
 .nav-links a:focus-visible {
   color: var(--cyan);


### PR DESCRIPTION
## Description

Improves keyboard and touch accessibility for the website navigation links.

The navigation links now have a minimum 44px height and additional padding to provide a clearer and more accessible interaction area.

The existing visual design and hover/focus styling are unchanged.

## Related Issue

Closes #137

## Testing

- `npm run check` — passed
- `npm run site:check-links` — passed
- `git diff --check` — passed

## Type of Change

- [x] fix: Bug fix
- [ ] feat: New feature
- [ ] style: UI/Theme changes
- [ ] chore: Build/Maintenance

## Checklist

- [x] Keeps the existing visual design unchanged
- [x] Improves accessibility of navigation links
- [x] Change is small and focused
- [x] Tested locally
- [x] `npm run check` passes
- [x] `npm run site:check-links` passes
- [x] `git diff --check` passes