### PR TITLE
test: cover daily issue duplicate handling

### DIFF
--- a/docs/DAILY_ISSUE_BOT.md
+++ b/docs/DAILY_ISSUE_BOT.md
@@ -12,6 +12,16 @@ It is designed to keep the repo active without creating spam.
 - Adds useful labels like `daily starter issue`, `good first issue`, and `beginner friendly`.
 - Skips creating the issue if the same daily starter issue already exists.
 
+## Duplicate Handling
+
+The bot never posts a starter issue whose title is already open.
+
+- It compares titles without caring about capitalization.
+- A skipped candidate does not use up a slot, so the bot keeps walking the backlog until it has enough fresh issues.
+- If every backlog item is already open, the run creates nothing and reports how many issues it could fill.
+
+This decision lives in `src/dailyIssueSelection.ts` as a pure function, so `tests/smoke.test.ts` can cover it without calling the GitHub API.
+
 ## Manual Run
 
 Maintainers can run it from GitHub:

--- a/scripts/createDailyIssue.ts
+++ b/scripts/createDailyIssue.ts
@@ -1,4 +1,10 @@
-import { dailyIssueBacklog, type DailyIssue } from "../src/dailyIssueBacklog.js";
+import { type DailyIssue } from "../src/dailyIssueBacklog.js";
+import {
+  chooseIssueCandidates,
+  chooseIssues,
+  issueAlreadyExists,
+  selectFreshDailyIssues
+} from "../src/dailyIssueSelection.js";
 import { scoreDailyIssue } from "../src/issueQuality.js";
 
 const apiBase = "https://api.github.com";
@@ -45,30 +51,6 @@ function requireEnv(name: string): string {
     throw new Error(`Missing required environment variable: ${name}`);
   }
   return value;
-}
-
-function getDayIndex(date = new Date()): number {
-  const start = Date.UTC(2026, 0, 1);
-  const today = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
-
-  return Math.max(0, Math.floor((today - start) / 86_400_000));
-}
-
-function chooseIssues(count: number, date = new Date()): DailyIssue[] {
-  const dayIndex = getDayIndex(date);
-  const startIndex = (dayIndex * count) % dailyIssueBacklog.length;
-
-  return Array.from({ length: count }, (_, offset) => dailyIssueBacklog[(startIndex + offset) % dailyIssueBacklog.length]);
-}
-
-function chooseIssueCandidates(date = new Date()): DailyIssue[] {
-  const dayIndex = getDayIndex(date);
-  const startIndex = dayIndex % dailyIssueBacklog.length;
-
-  return Array.from(
-    { length: dailyIssueBacklog.length },
-    (_, offset) => dailyIssueBacklog[(startIndex + offset) % dailyIssueBacklog.length]
-  );
 }
 
 function formatBody(issue: DailyIssue): string {
@@ -205,10 +187,6 @@ async function fetchOpenDailyStarterIssues(owner: string, repo: string, token: s
   );
 }
 
-function issueAlreadyExists(issues: GitHubIssue[], title: string): GitHubIssue | undefined {
-  return issues.find((issue) => issue.title.toLowerCase() === title.toLowerCase());
-}
-
 async function fetchAllDailyStarterIssues(owner: string, repo: string, token: string): Promise<GitHubIssue[]> {
   const issues = await githubRequest<GitHubIssue[]>(
     `/repos/${owner}/${repo}/issues?state=all&per_page=100&labels=${encodeURIComponent("daily starter issue")}`,
@@ -250,20 +228,15 @@ async function main(): Promise<void> {
 
   const openDailyIssues = await fetchOpenDailyStarterIssues(owner, repo, token);
   const allDailyIssues = await fetchAllDailyStarterIssues(owner, repo, token);
+  const { fresh, duplicates } = selectFreshDailyIssues(chooseIssueCandidates(), openDailyIssues, issueCount);
   let createdCount = 0;
 
-  for (const issue of chooseIssueCandidates()) {
-    if (createdCount >= issueCount) {
-      break;
-    }
+  for (const duplicate of duplicates) {
+    console.log(`Open daily issue already exists: ${duplicate.existing.html_url}`);
+  }
 
+  for (const issue of fresh) {
     await ensureLabels(owner, repo, token, issue.labels);
-
-    const existing = issueAlreadyExists(openDailyIssues, issue.title);
-    if (existing) {
-      console.log(`Open daily issue already exists: ${existing.html_url}`);
-      continue;
-    }
 
     const previouslyUsed = issueAlreadyExists(allDailyIssues, issue.title);
     if (previouslyUsed) {
@@ -280,7 +253,6 @@ async function main(): Promise<void> {
     });
 
     console.log(`Created daily issue: ${created.html_url}`);
-    openDailyIssues.push(created);
     allDailyIssues.push(created);
     createdCount += 1;
   }

--- a/src/dailyIssueSelection.ts
+++ b/src/dailyIssueSelection.ts
@@ -1,0 +1,75 @@
+import { dailyIssueBacklog, type DailyIssue } from "./dailyIssueBacklog.js";
+
+export interface ExistingIssue {
+  title: string;
+  html_url: string;
+}
+
+export interface DuplicateDailyIssue {
+  issue: DailyIssue;
+  existing: ExistingIssue;
+}
+
+export interface DailyIssueSelection {
+  fresh: DailyIssue[];
+  duplicates: DuplicateDailyIssue[];
+}
+
+export function getDayIndex(date = new Date()): number {
+  const start = Date.UTC(2026, 0, 1);
+  const today = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+
+  return Math.max(0, Math.floor((today - start) / 86_400_000));
+}
+
+export function chooseIssues(count: number, date = new Date()): DailyIssue[] {
+  const dayIndex = getDayIndex(date);
+  const startIndex = (dayIndex * count) % dailyIssueBacklog.length;
+
+  return Array.from({ length: count }, (_, offset) => dailyIssueBacklog[(startIndex + offset) % dailyIssueBacklog.length]);
+}
+
+export function chooseIssueCandidates(date = new Date()): DailyIssue[] {
+  const dayIndex = getDayIndex(date);
+  const startIndex = dayIndex % dailyIssueBacklog.length;
+
+  return Array.from(
+    { length: dailyIssueBacklog.length },
+    (_, offset) => dailyIssueBacklog[(startIndex + offset) % dailyIssueBacklog.length]
+  );
+}
+
+export function issueAlreadyExists(issues: ExistingIssue[], title: string): ExistingIssue | undefined {
+  return issues.find((issue) => issue.title.toLowerCase() === title.toLowerCase());
+}
+
+/**
+ * Decides which curated issues the bot should create today.
+ *
+ * Candidates whose title is already open are skipped, and the bot keeps walking
+ * the backlog until it has `count` fresh issues or runs out of candidates.
+ */
+export function selectFreshDailyIssues(
+  candidates: DailyIssue[],
+  openIssues: ExistingIssue[],
+  count: number
+): DailyIssueSelection {
+  const fresh: DailyIssue[] = [];
+  const duplicates: DuplicateDailyIssue[] = [];
+
+  for (const issue of candidates) {
+    if (fresh.length >= count) {
+      break;
+    }
+
+    const existing = issueAlreadyExists(openIssues, issue.title);
+    if (existing) {
+      duplicates.push({ issue, existing });
+      continue;
+    }
+
+    fresh.push(issue);
+  }
+
+  return { fresh, duplicates };
+}

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -5,6 +5,7 @@ import { buildChecklist } from "../src/checklist.js";
 import { findIssueFit } from "../src/issueFitFinder.js";
 import { issueIdeas } from "../src/issueIdeas.js";
 import { dailyIssueBacklog } from "../src/dailyIssueBacklog.js";
+import { chooseIssueCandidates, selectFreshDailyIssues, type ExistingIssue } from "../src/dailyIssueSelection.js";
 import { scoreDailyIssue } from "../src/issueQuality.js";
 import { getProgressionStep, listProgressionSteps, normalizeContributorLevel } from "../src/progressionPath.js";
 
@@ -142,5 +143,62 @@ const dailyIssueDryRun = execFileSync("node", [path.resolve("dist/scripts/create
 
 assert.ok(dailyIssueDryRun.includes("Daily issue dry-run: 5 curated issue(s)"));
 assert.equal((dailyIssueDryRun.match(/^## \d+\./gm) ?? []).length, 5);
+
+// Daily issue duplicate handling. These run against the pure selection helper,
+// so they never call the GitHub API.
+const candidates = chooseIssueCandidates(new Date("2026-03-01T00:00:00Z"));
+assert.equal(candidates.length, dailyIssueBacklog.length);
+
+function asOpenIssues(titles: string[]): ExistingIssue[] {
+  return titles.map((title, index) => ({
+    title,
+    html_url: `https://github.com/example/repo/issues/${index + 1}`
+  }));
+}
+
+const nothingOpen = selectFreshDailyIssues(candidates, [], 3);
+assert.equal(nothingOpen.fresh.length, 3);
+assert.equal(nothingOpen.duplicates.length, 0);
+
+// The first two candidates are already open, so the bot should skip them and
+// keep walking the backlog until it still has three fresh issues.
+const alreadyOpen = asOpenIssues(candidates.slice(0, 2).map((issue) => issue.title));
+const withDuplicates = selectFreshDailyIssues(candidates, alreadyOpen, 3);
+
+assert.deepEqual(
+  withDuplicates.duplicates.map((duplicate) => duplicate.issue.title),
+  alreadyOpen.map((issue) => issue.title)
+);
+assert.deepEqual(
+  withDuplicates.duplicates.map((duplicate) => duplicate.existing.html_url),
+  alreadyOpen.map((issue) => issue.html_url)
+);
+assert.equal(withDuplicates.fresh.length, 3);
+assert.deepEqual(
+  withDuplicates.fresh.map((issue) => issue.title),
+  candidates.slice(2, 5).map((issue) => issue.title)
+);
+
+// Duplicate titles are matched without caring about capitalization.
+const differentCasing = selectFreshDailyIssues(
+  candidates,
+  asOpenIssues([candidates[0].title.toUpperCase()]),
+  1
+);
+
+assert.equal(differentCasing.duplicates.length, 1);
+assert.equal(differentCasing.fresh.length, 1);
+assert.notEqual(differentCasing.fresh[0].title, candidates[0].title);
+
+// When the whole backlog is already open the bot creates nothing instead of
+// posting duplicates.
+const everythingOpen = selectFreshDailyIssues(
+  candidates,
+  asOpenIssues(candidates.map((issue) => issue.title)),
+  5
+);
+
+assert.equal(everythingOpen.fresh.length, 0);
+assert.equal(everythingOpen.duplicates.length, dailyIssueBacklog.length);
 
 console.log("Smoke tests passed.");


### PR DESCRIPTION
Closes #129

## What this changes

The daily issue bot already skips starter issues whose title is open and keeps walking the backlog for fresh candidates, but nothing protected that behavior. This adds tests for it.

The decision lived inline in `scripts/createDailyIssue.ts`, tangled with the `fetch` calls, so it could not be tested without hitting GitHub. Following the issue's note that "extracting a tiny pure helper is okay", the selection logic moved to `src/dailyIssueSelection.ts`:

| Helper | Purpose |
| --- | --- |
| `getDayIndex`, `chooseIssues`, `chooseIssueCandidates` | rotate the backlog by day (moved as-is) |
| `issueAlreadyExists` | case-insensitive title lookup (moved as-is) |
| `selectFreshDailyIssues` | **new** — returns `{ fresh, duplicates }` for a set of candidates |

`createDailyIssue.ts` now only does I/O and got 40 lines shorter. Behavior is unchanged, including the `Open daily issue already exists: <url>` log line.

## Tests

Four cases in `tests/smoke.test.ts`, all against the pure helper, so **no GitHub API calls**:

- Nothing open, so the first three candidates are chosen.
- The first two candidate titles are already open, so they are reported as duplicates and the bot still returns three fresh issues from further down the backlog. This is the case the issue asks about — a skipped duplicate must not use up a slot.
- A title that differs only in capitalization still counts as a duplicate.
- Every backlog title open, so nothing is created and all candidates are reported as duplicates.

I checked the tests actually fail when the behavior breaks, rather than passing by accident:

- Deleting the duplicate-skip branch gives `AssertionError`
- Changing the match to `issue.title === title` gives `AssertionError`

## Verification

```
$ npm run check
Smoke tests passed.
Unknown command CLI test passed.
Site link check passed.

$ npm run automation:health
(all six dry-runs pass)
```

## Note for maintainers

While looking for an issue I noticed **#161, #123, and #122 are already implemented on `main`** (via #160 and #153) but still open — `printProfiles`, `fit --help`, and `tests/cli.test.ts` all exist. Might be worth closing them so new contributors do not start work that is already done. Happy to open a separate issue for that if it helps.
