### PR TITLE
docs: document website and accessibility labels

### DIFF
--- a/docs/AUTOMATION_HEALTH.md
+++ b/docs/AUTOMATION_HEALTH.md
@@ -17,6 +17,13 @@ The goal is not to make the repo noisy. The goal is to catch broken automation e
 | `Contributor Proof After Merge` | Thanks contributors, closes linked issues, updates the First Merge Wall, and creates contributor passports | Per-PR concurrency guard, direct issue listing instead of search API |
 | `Automation Health` | Dry-runs automation scripts daily without writing to GitHub | No token needed, read-only permissions |
 
+## Website and Accessibility Labels
+
+Use the `website` label for issues involving the repository website, pages, site content, navigation, or other website-facing changes.
+Use the `accessibility` label for issues focused on making the website or project interfaces more accessible, including keyboard navigation, visible focus states, semantic markup, labels, and related accessibility improvements.
+
+When an issue clearly involves both areas, maintainers may apply both labels.
+
 ## Daily Health Check
 
 `Automation Health` runs this command:


### PR DESCRIPTION
Document when maintainers should use the website and accessibility labels, including guidance for issues that fall under both areas.

## What changed?

* Added documentation for when to use the `website` label.
* Added documentation for when to use the `accessibility` label.
* Documented when both labels can be applied to the same issue.

## Why does this help?

* Makes website and accessibility issues easier for maintainers to classify consistently.
* Gives contributors clearer guidance when creating or triaging issues.
* Keeps the existing automation behavior unchanged.

## Testing

* [  ] I ran `npm run check`
* [ ] Documentation-only change reviewed for formatting and clarity.

## Related issue

Closes #148
