### PR TITLE
Enable cancellation of in-progress contributor queue jobs

### DIFF
--- a/.github/workflows/contributor-queue.yml
+++ b/.github/workflows/contributor-queue.yml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 10
     concurrency:
       group: contributor-queue-${{ github.repository }}
-      cancel-in-progress: false
+      cancel-in-progress: true
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## What changed?

-

## Why does this help?

-

## Testing

- [ ] I ran `npm run check`

## Related issue

Closes #
