### PR TITLE
fix: print clean CLI errors instead of raw stack traces

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -155,4 +155,10 @@ function main(): void {
   throw new Error(`Unknown command: ${command}`);
 }
 
-main();
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## What changed?

- Wrapped the CLI entry point call in `src/cli.ts` in a try/catch. Errors thrown during input validation (`check --profile`, `fit --skill`, `fit --time`, `next --level`) or from an unknown command are now caught and printed as a single clean line (`Error: <message>`) with exit code 1, instead of an uncaught exception.

## Why does this help?

- This project's whole purpose is to be welcoming to first-time contributors, but any invalid CLI input currently dumps a full raw Node.js stack trace to the terminal — intimidating and confusing for a beginner. A clean, single-line error message matches the friendly tone of the rest of the CLI output and makes it obvious what to fix, without changing any existing error text (so it's a purely cosmetic, low-risk fix).

## Testing

-  I ran `npm run check`
- Manually verified clean output and exit code 1 on: `fit --skill bogus`, `fit --time bogus`, `next --level bogus`, `check --profile expert`, and an unknown command — each now prints `Error: <message>` with no stack trace.

## Related issue

Closes #

