### PR TITLE
docs: add guide for resolving markdown merge conflicts

### DIFF
--- a/docs/RESOLVING_MERGE_CONFLICTS.md
+++ b/docs/RESOLVING_MERGE_CONFLICTS.md
@@ -1,0 +1,18 @@
+# Resolving Markdown Merge Conflicts in GitHub UI
+
+Merge conflicts happen when two people change the same part of a file differently. GitHub's UI allows you to resolve these directly in your browser without needing to use the command line.
+
+## How to Resolve Conflicts via GitHub UI
+
+If you see a "This branch has conflicts that must be resolved" message in your Pull Request:
+
+1. **Click the "Resolve conflicts" button** in the PR view.
+2. **Identify the conflict markers**: GitHub will highlight the conflicting lines:
+   - `<<<<<<<` : Your changes (the incoming changes).
+   - `=======` : The separator between changes.
+   - `>>>>>>>` : The existing changes (the target branch).
+3. **Edit the file**: Manually remove the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) and keep the version of the code that is correct.
+4. **Mark as resolved**: Once the code looks correct, click the "Mark as resolved" button at the top right of the editor.
+5. **Commit the merge**: Click "Commit merge" to finish the process.
+
+Your PR will automatically update, and if all conflicts are resolved, you can proceed with the merge.


### PR DESCRIPTION
## What changed?

- Added a new documentation file docs/RESOLVING_MERGE_CONFLICTS.md detailing step-by-step instructions on how to resolve markdown merge conflicts directly in the GitHub UI.

## Why does this help?

- Provides a clear, beginner-friendly guide for new contributors who encounter merge conflicts and want to resolve them using the web interface.

## Testing

- [x] I ran `npm run check` and verified all tests, builds, and link checks pass successfully.
> open-source-starter-lab@0.1.0 check
> npm run build && npm test && npm run demo && npm run site:check-links

Smoke tests passed.
Unknown command CLI test passed.
Open Source Starter Lab - beginner checklist
Readiness score: 76/100
Site link check passed.

## Related issue

Closes #186 