### PR TITLE
docs: add guide explaining squash merge and commit history

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ npm run check
 - **Title**: Use conventional commits style (e.g. `docs: improve Git branches guide`, `fix: CI lint error`).
 - **Description**: Include What changed, Why, How tested, Screenshots/command output.
 - **Scope**: Small and reviewable in <10 minutes.
-- **Quality**: Clean commits, no unrelated changes.
+- **Quality**: Clean final PR structure, no unrelated changes. (Note: Local exploratory commits can be messy; read our [Merge Strategy Guide](docs/MERGE_STRATEGY.md) to learn how squash merging handles them).
 - **CI**: All checks must pass before review.
 
 ## Review Process

--- a/docs/MERGE_STRATEGY.md
+++ b/docs/MERGE_STRATEGY.md
@@ -1,0 +1,23 @@
+# Understanding Squash Merge: Why Your Messy Commits Don't Matter
+
+If you are new to open source, you might worry that making lots of small commits (like "fix typo", "oops", or "try again") will clutter the project's history. **Don't worry—they don't matter at all!**
+
+## What is a Squash Merge?
+
+When a maintainer merges your Pull Request, they have a few options. This repository uses a **Squash and Merge** strategy. 
+
+Instead of adding all 10 or 20 of your individual commit messages into the main project history, GitHub automatically "squashes" them into **one single, clean commit** when merging into the `main` branch.
+
+## Why Messy Commits are Totally Fine During Development
+
+* **Trial and Error is Normal:** Experienced developers make plenty of typos and syntax errors while building features. Making frequent commits locally helps you save your progress and roll back if something breaks.
+* **No Pressure:** You do not need to worry about writing a perfect commit message for every single change you make on your local branch.
+
+## Why a Clean `main` Branch History Matters
+
+By squashing all contributions down to one commit per Pull Request:
+* The project's `git log` remains clean, readable, and linear.
+* If a bug is ever introduced, it is much easier to track down the exact Pull Request responsible for it.
+* Release notes and changelogs are easy to read and understand.
+
+Write freely, commit often locally, and let the squash merge handle the cleanup!


### PR DESCRIPTION
## What changed?

- Added a new documentation file `docs/MERGE_STRATEGY.md` explaining how squash merging works and why messy local commit histories do not matter for contributors.
- Updated `CONTRIBUTING.md` to include a reference link to the new Merge Strategy Guide under the Pull Request Guidelines section.

## Why does this help?

- Reassures first-time contributors who worry about cluttering the repository with frequent exploratory or trial-and-error commits (e.g., "fix typo", "oops").
- Reduces repetitive questions in discussions by clearly documenting the repository's merge practices upfront.

## Testing

- [x] I ran `npm run check` and verified all tests, builds, and link checks pass successfully.

## Related issue

Closes #182