### PR TITLE
docs: add npm ci lockfile troubleshooting guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ npm install
 npm run check
 ```
 
+CI installs with `npm ci`, which fails if `package-lock.json` is out of sync with `package.json`. If you hit that error, see the [npm ci Troubleshooting Guide](docs/NPM_CI_TROUBLESHOOTING.md).
+
 ## Contribution Workflow (Professional Standards)
 
 1. **Find an issue** — Look for `good first issue`, `help wanted`, or skill-matched labels.

--- a/docs/NPM_CI_TROUBLESHOOTING.md
+++ b/docs/NPM_CI_TROUBLESHOOTING.md
@@ -1,0 +1,49 @@
+# Fixing `npm ci` Lockfile Errors
+
+## Why CI uses `npm ci` and not `npm install`
+
+`npm install` treats `package-lock.json` as a starting point: if the lockfile does not match `package.json`, it quietly updates the lockfile and installs whatever it decided was correct. `npm ci` treats the lockfile as the source of truth: it deletes `node_modules`, installs the exact versions recorded in the lockfile, and fails immediately if the lockfile and `package.json` disagree. That strictness is the point — CI must install the same dependency tree every run, so a build that passes today passes tomorrow. A failing `npm ci` in CI usually means the lockfile is out of date, not that your change is broken.
+
+## The error
+
+```text
+npm error `npm ci` can only install packages when your package.json and
+npm error package-lock.json are in sync.
+```
+
+## The one-line fix
+
+Regenerate the lockfile from `package.json`:
+
+```bash
+rm -rf node_modules package-lock.json && npm install
+```
+
+On Windows PowerShell:
+
+```powershell
+Remove-Item -Recurse -Force node_modules, package-lock.json; npm install
+```
+
+Then run `npm ci` again to confirm it passes, and commit the updated `package-lock.json` with your change.
+
+## Check your Node version first
+
+A different Node version can produce a different lockfile, so check that before regenerating anything:
+
+```bash
+node -v
+```
+
+Compare it with:
+
+- the `engines` field in `package.json`, if the project declares one
+- the `node-version` used by CI in [.github/workflows/ci.yml](../.github/workflows/ci.yml)
+
+If they do not match, switch Node versions (`nvm use 24`) and try `npm ci` again before committing a new lockfile.
+
+## Before you open the pull request
+
+- Commit `package-lock.json` if it changed. Do not commit `node_modules`.
+- Only include the lockfile if your change actually needed it. An unrelated lockfile churn makes the PR harder to review.
+- Run `npm run check` once more so the build, tests, and link check all pass.


### PR DESCRIPTION
## What changed?

- Added `docs/NPM_CI_TROUBLESHOOTING.md`, a short guide explaining why CI uses `npm ci`, the exact lockfile-mismatch error, and the one-line fix.
- Linked the guide from `CONTRIBUTING.md`, right after the development setup block where `npm install` is introduced.

## Why does this help?

CI installs with `npm ci`, which fails hard on lockfile drift, while local `npm install` silently repairs it. New contributors hit the red check and cannot tell whether it is their mistake or a real bug. The guide gives them the command that fixes it and the Node version check that prevents it.

Covers the acceptance criteria from #180:
- `npm ci` vs `npm install` explained in one paragraph
- the common fix (remove `node_modules` + `package-lock.json`, reinstall), with a Windows PowerShell equivalent
- checking `node -v` against the `engines` field and the CI `node-version`
- linked from `CONTRIBUTING.md`

## Testing

- I ran `npm run check`

Passing before and after the change — build, both test suites, demo, and site link check:

Smoke tests passed.
Unknown command CLI test passed.
Site link check passed.

Docs-only change; no source, tests, or dependencies touched.

## Related issue

Closes #180
