### PR TITLE
fix: detect stuck queued workflows

### DIFF
--- a/.github/workflows/automation-health.yml
+++ b/.github/workflows/automation-health.yml
@@ -73,7 +73,7 @@ jobs:
           WARNING_MESSAGES=""
           
           # Process each queued run
-          echo "$QUEUED_RUNS" | jq -c '.' | while read -r RUN; do
+          while read -r RUN; do
             RUN_NAME=$(echo "$RUN" | jq -r '.name')
             RUN_ID=$(echo "$RUN" | jq -r '.id')
             RUN_URL=$(echo "$RUN" | jq -r '.html_url')
@@ -92,7 +92,7 @@ jobs:
             else
               echo "✅ Workflow '$RUN_NAME' is queued but only $AGE_MINUTES minutes old (under ${THRESHOLD_MINUTES}m threshold)."
             fi
-          done
+          done < <(echo "$QUEUED_RUNS" | jq -c '.')
           
           # Output summary
           if [ $STUCK_COUNT -gt 0 ]; then
@@ -102,6 +102,13 @@ jobs:
             echo ""
             echo "📋 Summary of stuck workflows:"
             echo -e "$WARNING_MESSAGES"
+            echo "## ⚠️ Stuck Workflows Detected" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Found **$STUCK_COUNT** workflow(s) queued for more than **$THRESHOLD_MINUTES minutes**." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo -e "$WARNING_MESSAGES" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Please investigate GitHub Actions runner availability or cancel/restart the affected runs." >> "$GITHUB_STEP_SUMMARY"
             echo ""
             echo "💡 Suggestion: Check if GitHub Actions is experiencing issues, or manually cancel/restart these runs."
             echo "🔗 View all queued runs: https://github.com/${{ github.repository }}/actions?query=is%3Apr+status%3Aqueued"
@@ -110,6 +117,9 @@ jobs:
             exit 0 # Don't fail the job
           else
             echo "✅ All queued runs are within the $THRESHOLD_MINUTES minute threshold."
+            echo "## ✅ Automation Health" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No workflows have been queued for more than **$THRESHOLD_MINUTES minutes**." >> "$GITHUB_STEP_SUMMARY"
             echo "status=healthy" >> $GITHUB_OUTPUT
           fi
 

--- a/docs/AUTOMATION_HEALTH.md
+++ b/docs/AUTOMATION_HEALTH.md
@@ -34,36 +34,23 @@ When an issue clearly involves both areas, maintainers may apply both labels.
 
 ```bash
 npm run automation:health
-
-
----
-
-## 📋 What Changed
-
-| Section | Change |
-|---------|--------|
-| **Active Automations Table** | Updated `Automation Health` row to mention queued run monitoring and `continue-on-error: true` |
-| **New Section: Queued Run Monitor** | Added full explanation of how it works, what warnings look like, why it matters, and what to do |
-| **Recovery Steps** | Added step 7 for queued run warnings |
-| **Long-Term Rule** | Added note about monitoring new automations |
+```
 
 ---
 
-## 🚀 Your Next Steps
+### Queued Run Monitor
 
-1. **Replace the content** of your file with this updated version
-2. **Make sure the file name is correct**: `docs/AUTOMATION_HEALTH.md` (not `# Automation Health.txt`)
-3. **Commit and push:**
+The health check also looks for workflow runs that are still in the `queued` state.
 
-```bash
-git add docs/AUTOMATION_HEALTH.md
-git commit -m "docs: update automation health docs with queued run monitor
+A queued run is considered stuck when it has been waiting for more than **20 minutes**.
 
-- Add queued run monitor section
-- Update active automations table
-- Add recovery step for stuck workflows
-- Update long-term rule
+When a stuck run is found, the workflow:
 
-Closes #184"
+- Logs a warning with the workflow name, run number, age, and URL.
+- Adds a warning to the GitHub Actions workflow summary.
+- Lists the affected runs so they can be investigated.
+- Keeps the health check job successful instead of failing because of a single stuck run.
 
-git push origin automation/queued-workflow-check
+A queued run that is younger than 20 minutes is reported as healthy and does not trigger a warning.
+
+If a stuck run is reported, check GitHub Actions runner availability and consider cancelling or restarting the affected run.


### PR DESCRIPTION
## What changed?

- Fixed the queued workflow monitor so stuck-run counts and warning messages are tracked correctly.
- Added stuck workflow details to the GitHub Actions job summary.
- Updated AUTOMATION_HEALTH.md to document queued workflow monitoring and the 20-minute threshold.
- Removed outdated instructions from the automation health documentation.


## Why does this help?

- Ensures workflows queued for more than 20 minutes are detected reliably.
- Makes stuck workflow information easier to find in the GitHub Actions summary.
- Gives maintainers clear guidance for investigating and recovering stuck runs.

## Testing

- [x] I ran `npm run check`
Command output:

```text
Smoke tests passed.
Unknown command CLI test passed.
Readiness score: 76/100
Site link check passed.
Screenshot:
<img width="588" height="745" alt="npm run check output" src="https://github.com/user-attachments/assets/bcaeb5d6-2c07-478b-9d04-472975853771" />

- [x] I ran `git diff --check`
with no errors

## Related issue

Closes #198
