### PR TITLE
docs: add commit message guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ CI installs with `npm ci`, which fails if `package-lock.json` is out of sync wit
 ## Pull Request Guidelines (Top Company Level)
 
 - **Title**: Use conventional commits style (e.g. `docs: improve Git branches guide`, `fix: CI lint error`).
+- **Commit messages**: See the [Commit Message Guide](docs/COMMIT_MESSAGE_GUIDE.md) for examples and conventions.
 - **Description**: Include What changed, Why, How tested, Screenshots/command output.
 - **Scope**: Small and reviewable in <10 minutes.
 - **Quality**: Clean final PR structure, no unrelated changes. (Note: Local exploratory commits can be messy; read our [Merge Strategy Guide](docs/MERGE_STRATEGY.md) to learn how squash merging handles them).

--- a/docs/COMMIT_MESSAGE_GUIDE.md
+++ b/docs/COMMIT_MESSAGE_GUIDE.md
@@ -1,0 +1,66 @@
+# Commit Message Guide
+
+Good commit messages make the project history easier to understand and review.
+
+## Our convention
+
+Use a short prefix followed by a clear description of the change:
+
+* `docs:` — documentation changes
+* `fix:` — bug fixes or corrections
+* `feat:` — new features or capabilities
+
+These prefixes are a project convention, not a CI gate. They help maintainers quickly understand what a commit contains.
+
+## Real examples from this repository
+
+### `docs:`
+
+```text
+docs: add guide explaining squash merge and commit history (#194)
+```
+
+This clearly identifies a documentation change and describes what was added.
+
+### `fix:`
+
+```text
+fix: improve FAQ accessibility (#168)
+```
+
+This identifies a correction and briefly explains what was fixed.
+
+### `feat:`
+
+```text
+feat: add CLI fit help text (#138)
+```
+
+This identifies a new capability and describes the feature.
+
+## Weak vs. better
+
+A vague message:
+
+```text
+docs: update contributor proof
+```
+
+A clearer message:
+
+```text
+docs: refine first PR review guide and clean up formatting (#179)
+```
+
+The second message tells the reviewer what documentation was changed instead of only saying that something was updated.
+
+## Quick checklist
+
+Before committing, ask:
+
+* Does the message start with an appropriate prefix?
+* Does it describe the actual change?
+* Is it short enough to understand at a glance?
+* Would another contributor understand the purpose without opening the commit?
+
+For pull requests, also follow the contribution and testing guidance in `CONTRIBUTING.md`.


### PR DESCRIPTION
## Summary

- Add a guide documenting the repository's commit message convention
- Include real `docs:`, `fix:`, and `feat:` examples from git history
- Add a weak vs. better commit message example
- Link the guide from `CONTRIBUTING.md`

## Testing

- `npm run check` ✅
- Smoke tests passed
- CLI tests passed
- Site link check passed

Closes #183
