### PR TITLE
test: add whitespace normalization test for daily issue duplicate handling

### DIFF
--- a/src/dailyIssueSelection.ts
+++ b/src/dailyIssueSelection.ts
@@ -40,7 +40,7 @@ export function chooseIssueCandidates(date = new Date()): DailyIssue[] {
 }
 
 export function issueAlreadyExists(issues: ExistingIssue[], title: string): ExistingIssue | undefined {
-  return issues.find((issue) => issue.title.toLowerCase() === title.toLowerCase());
+  return issues.find((issue) => issue.title.trim().toLowerCase() === title.trim().toLowerCase());
 }
 
 /**

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -144,8 +144,8 @@ const dailyIssueDryRun = execFileSync("node", [path.resolve("dist/scripts/create
 assert.ok(dailyIssueDryRun.includes("Daily issue dry-run: 5 curated issue(s)"));
 assert.equal((dailyIssueDryRun.match(/^## \d+\./gm) ?? []).length, 5);
 
-// Daily issue duplicate handling. These run against the pure selection helper,
-// so they never call the GitHub API.
+// Daily issue duplicate handling tests protect backlog selection from creating duplicate issues
+// without making live GitHub API calls.
 const candidates = chooseIssueCandidates(new Date("2026-03-01T00:00:00Z"));
 assert.equal(candidates.length, dailyIssueBacklog.length);
 
@@ -189,6 +189,17 @@ const differentCasing = selectFreshDailyIssues(
 assert.equal(differentCasing.duplicates.length, 1);
 assert.equal(differentCasing.fresh.length, 1);
 assert.notEqual(differentCasing.fresh[0].title, candidates[0].title);
+
+// Duplicate titles differing only by leading/trailing whitespace are also matched.
+const whitespaceDuplicate = selectFreshDailyIssues(
+  candidates,
+  asOpenIssues([`   ${candidates[0].title}   `]),
+  1
+);
+
+assert.equal(whitespaceDuplicate.duplicates.length, 1);
+assert.equal(whitespaceDuplicate.fresh.length, 1);
+assert.notEqual(whitespaceDuplicate.fresh[0].title, candidates[0].title);
 
 // When the whole backlog is already open the bot creates nothing instead of
 // posting duplicates.


### PR DESCRIPTION
### Summary
Adds an edge-case test asserting that duplicate daily issue matching handles leading/trailing whitespace variances, updates `issueAlreadyExists` to trim titles, and adds documentation clarifying the purpose of the offline duplicate test suite.

### Changes
- Added `.trim()` to title comparisons in `src/dailyIssueSelection.ts`
- Added `whitespaceDuplicate` test in `tests/smoke.test.ts`
- Added docstring explaining why offline duplicate handling tests protect backlog queue selection

### Verification
- `npm run check` passed cleanly (TypeScript build, smoke tests, CLI tests, link check)

Closes #165 