### PR TITLE
docs: add test commit message example

### DIFF
--- a/docs/COMMIT_MESSAGE_GUIDE.md
+++ b/docs/COMMIT_MESSAGE_GUIDE.md
@@ -9,6 +9,7 @@ Use a short prefix followed by a clear description of the change:
 * `docs:` — documentation changes
 * `fix:` — bug fixes or corrections
 * `feat:` — new features or capabilities
+* `test:` — test changes
 
 These prefixes are a project convention, not a CI gate. They help maintainers quickly understand what a commit contains.
 
@@ -37,6 +38,14 @@ feat: add CLI fit help text (#138)
 ```
 
 This identifies a new capability and describes the feature.
+
+### `test:`
+
+```text
+test: add whitespace duplicate test and selection docs (#215)
+```
+
+This identifies a change related to tests and briefly describes what was added.
 
 ## Weak vs. better
 


### PR DESCRIPTION
## What changed?

- Added the `test:` commit message convention.
- Added a real `test:` commit example from this repository.

## Why does this help?

- Documents another commit message prefix used by the project.
- Gives contributors a real example to follow when writing test-related commits.

## Testing

- [x] I ran `npm run check`

## Related issue

Closes #220
