### PR TITLE
docs: add guide for rejected git pushes

### DIFF
--- a/docs/CHOOSING_FIRST_ISSUE.md
+++ b/docs/CHOOSING_FIRST_ISSUE.md
@@ -24,6 +24,7 @@ Look for issues that include:
 
 ```md
 I would like to work on this. My plan is to update the docs and run `npm run check`.
+```
 
 
 ---
@@ -36,6 +37,8 @@ Good first issues are small, specific, and easy to verify. Examples from this re
 - Adding one small example to an existing guide.
 - Adding a focused test for an existing behavior.
 - Fixing a small documentation typo or broken link.
+- Improving a focused section in `docs/GIT_BRANCHES.md` or `docs/FIRST_PULL_REQUEST.md`.
+- Adding a beginner-focused case to `tests/smoke.test.ts` without changing existing behavior.
 
 ## Risky First Issues
 
@@ -45,5 +48,7 @@ Some issues may be harder for a first contribution because they have a large or 
 - Changing core architecture or major project structure.
 - Fixing a bug that requires access to production systems or private data.
 - Tasks without clear acceptance criteria or a way to verify the result.
+- Changing command behavior across `src/cli.ts` and its related tests in one issue.
+- Modifying GitHub automation such as `scripts/createDailyIssue.ts`, especially when it requires repository access or credentials.
 
 When in doubt, comment on the issue before starting work. Briefly explain what you plan to change and ask whether the scope is appropriate for a first contribution.

--- a/docs/GIT_PUSH_REJECTED.md
+++ b/docs/GIT_PUSH_REJECTED.md
@@ -1,46 +1,112 @@
 # Fixing "Updates Were Rejected" Git Push Errors
 
-## Why does this happen?
+## What does a rejected push mean?
 
-When you see this error:
+A rejected push means GitHub did not accept the commits you tried to send. Git protects the remote branch when accepting your push would overwrite commits that are already there.
 
-```
-error: failed to push some refs to 'origin'
-hint: Updates were rejected because the remote contains work that you do not have locally.
-```
-
-It means the remote branch (on GitHub) has commits that your local branch does not have yet. Git refuses to push so you do not accidentally overwrite someone else's work.
-
-## The safe fix — rebase
-
-Run these commands one at a time:
+A common version of this error is:
 
 ```
+! [rejected]        main -> main (fetch first)
+error: failed to push some refs
+```
+
+This usually happens because the remote branch contains commits that are not in your local branch. For example, someone may have pushed a change to `main` after you last downloaded the repository. Your local branch is now behind the remote branch, so Git asks you to bring your branch up to date first.
+
+## Safely inspect the situation
+
+Do not start by forcing the push. Run these commands one at a time:
+
+```bash
+git status
+git remote -v
+git fetch origin
+git log --oneline --decorate --graph --all
+```
+
+These commands show your current branch and working tree, confirm which repository is called `origin`, download the latest remote history without changing your files, and show how your local and remote branches relate to each other.
+
+Make sure you know which branch you are on before continuing. In most contributions, you should work on a feature branch rather than pushing directly to `main`.
+
+## The safe solution for `main`
+
+If you intentionally work on your local `main` branch and it has local commits to keep, rebase those commits on top of the latest remote `main`:
+
+```bash
 git pull --rebase origin main
 ```
 
 Then push again:
 
+```bash
+git push origin main
 ```
-git push origin your-branch-name
+
+Rebase replays your local commits after the remote commits. It keeps the history linear without creating an unnecessary merge commit.
+
+## The safe solution for a feature branch
+
+For a feature branch, update it with the latest `main` before pushing your branch:
+
+```bash
+git fetch origin
+git rebase origin/main
 ```
 
-## What does `--rebase` do?
+When the rebase finishes, push your feature branch:
 
-Instead of creating a messy merge commit, rebase replays your local commits on top of the latest remote commits. Your history stays clean and linear.
-
-## ⚠️ Warning — commands to avoid
-
-Do not run this unless you fully understand what it does:
-
+```bash
+git push origin my-feature-branch
 ```
+
+Replace `my-feature-branch` with the name of your branch. If the branch already has a pull request, rebasing may change its commit history. That is expected, but check the changes carefully before pushing.
+
+## If the rebase stops for a conflict
+
+Git pauses when it cannot combine your changes with a remote change automatically. Run `git status` to see which files need attention. Open each file, choose the correct content, and remove the conflict-marker lines that begin with `<<<<<<<`, `=======`, and `>>>>>>>`.
+
+After resolving a file, stage it and continue the rebase:
+
+```bash
+git add <file>
+git rebase --continue
+```
+
+Repeat these steps if Git reports another conflict. If Git opens an editor for a commit message, keep the message or update it, then save and close the editor so the rebase can continue.
+
+If you are unsure how to resolve a conflict, or the result does not look right, abort the rebase safely:
+
+```bash
+git rebase --abort
+```
+
+This returns your branch to the state it had before the rebase started. You can then inspect the situation again or ask for help.
+
+## Why not use `git push --force`?
+
+Do not casually run:
+
+```bash
 git push --force
 ```
 
-Force pushing rewrites remote history and can permanently delete other people's commits. When in doubt, use `--rebase` instead.
+Force pushing replaces the remote branch history with your local history. It can delete commits that other contributors have pushed and disrupt an existing pull request. Beginners should not use it to bypass a rejected push.
 
-## Still stuck?
+## When is `--force-with-lease` appropriate?
 
-- Run `git status` to see the current state of your branch.
-- Run `git log --oneline -5` to see your last 5 commits.
-- Ask for help in Discussions before using any destructive command.
+Sometimes you intentionally rewrite your own feature branch, such as after rebasing a pull request branch. After checking the branch and confirming that nobody else's new commits will be overwritten, the safer force-push option is:
+
+```bash
+git push --force-with-lease origin my-feature-branch
+```
+
+`--force-with-lease` refuses to push if the remote branch changed since your last fetch. It is still a history-rewriting operation, so coordinate with anyone sharing the branch and ask for help if you are unsure. It should not be used as the first response to a `fetch first` error.
+
+## Before you push
+
+- Confirm you are on the intended feature branch with `git status`.
+- Check that your working tree contains only the changes you expect.
+- Fetch recent remote changes when the branch may be out of date.
+- Review the commit graph if Git reports a rejected push.
+- Rebase and resolve conflicts before pushing again.
+- Do not use a force push unless you understand the history change and have checked with collaborators.


### PR DESCRIPTION
## What changed

Added a focused guide for handling rejected Git pushes, including:

- Inspecting the local and remote branch state
- Safely rebasing main and feature branches
- Resolving rebase conflicts
- Aborting a rebase safely
- Explaining the risks of force pushing
- Using --force-with-lease when intentionally rewriting a feature branch
- A pre-push checklist

## Testing

Ran:

npm run check
git diff --check

Result: PASSED

## Issue

Closes #223