### PR TITLE
docs: improve maintainer triage rules and issue quality guide

### DIFF
--- a/docs/ISSUE_QUALITY.md
+++ b/docs/ISSUE_QUALITY.md
@@ -36,3 +36,10 @@ If a new contributor cannot answer these questions in under one minute, the issu
 ## Why This Matters
 
 Beginner repos often fail because the issue looks easy but hides missing context. This repo should do the opposite: small scope, obvious first step, visible finish line.
+
+## 🔗 Related Maintainer Tools
+
+- Use ISSUE_DECODER.md to validate if an issue is beginner-friendly
+- Use MAINTAINER_PLAYBOOK.md for triaging and labeling decisions
+
+If an issue cannot be understood in under 1 minute using these guides, it should be rewritten or split.

--- a/docs/MAINTAINER_PLAYBOOK.md
+++ b/docs/MAINTAINER_PLAYBOOK.md
@@ -11,6 +11,81 @@ Strong issues include:
 - Expected test command
 - Difficulty label
 
+## 🧩 Triage Rules for Idea Issues (`needs triage`)
+
+### When to KEEP
+- Clear problem statement exists
+- Scope is small and actionable
+- Can be assigned to a contributor immediately
+- Has enough context to start work
+
+### When to SPLIT
+- Multiple unrelated features in one issue
+- Too large for a single contributor
+- Requires different skill areas (UI + backend + infra)
+- Cannot be completed in one PR
+
+### When to CLOSE
+- Too vague or unclear (“make UI better”)
+- No real problem described
+- Duplicate of existing issue
+- Out of scope for this repository
+- Cannot be acted on even after clarification
+
+### When to CONVERT
+- Good idea but unstructured
+- Needs rewriting into proper issue format
+- Requires clarification questions before implementation
+- Can become a valid feature with proper structure
+
+## 🏷️ Required Labels for Triaged Issues
+
+Always add at least one from each category:
+
+### Skill Level
+- skill: beginner
+- skill: intermediate
+- skill: advanced
+
+### Time Estimate
+- time: small
+- time: medium
+- time: large
+
+### Contributor Level
+- contributor: first-time
+- contributor: returning
+- contributor: maintainer-track
+
+Optional labels:
+- needs-info
+- good-first-issue
+- enhancement
+- idea
+
+## 💬 Maintainer Reply Templates
+
+### Needs Clarification
+Thanks for the idea! Could you clarify the problem this solves and the expected behavior?
+
+### Converted to Issue
+Thanks! We’ve converted this idea into a structured issue for implementation.
+
+### Closing Issue
+Thanks for the suggestion. This is currently too vague or out of scope, so we’re closing it for now.
+
+### Split Issue
+This issue is too large for a single task, so we’ve split it into smaller actionable issues.
+
+## ✅ Quality Check Before Closing or Approving
+
+- Clear problem statement exists
+- Issue is actionable
+- Not a duplicate
+- Proper labels added
+- Scope is appropriate for one contributor
+- Can be understood by a new contributor
+
 ## Decode Good First Issues
 
 Before publishing a beginner issue, make sure a new contributor can answer:


### PR DESCRIPTION
## What changed?

- Added structured triage rules (keep / split / close / convert)
- Improved labeling guidance for skill, time, and contributor level
- Added maintainer reply templates
- Improved issue quality clarity and beginner readiness rules
- Linked related maintainer tools for better workflow consistency

## Why does this help?

-This helps ensure issues remain actionable, beginner-friendly, and well-scoped.

## Testing

- [ ] I ran `npm run check`

## Related issue

Closes #
