### PR TITLE
docs: add pro tip to reading CI failures guide

### DIFF
--- a/docs/READING_CI_FAILURES.md
+++ b/docs/READING_CI_FAILURES.md
@@ -73,3 +73,5 @@ I expected the build to pass after changing the CLI output.
 ```
 
 That gives maintainers enough context to help without guessing.
+
+ > **Pro Tip:** Don't panic when you see red text! Take a deep breath and look for the specific error line.


### PR DESCRIPTION
## What changed?

- Added a pro-tip to the bottom of the `READING_CI_FAILURES.md` guide.

## Why does this help?

- It encourages beginners not to panic when they see red text in their logs, and helps them focus on finding the specific error line.

## Testing

- [x] I ran `npm run check`

## Related issue

Closes #119
