### PR TITLE
docs: fill in handling-github-api-errors recipe

### DIFF
--- a/docs/recipes/adding-a-new-label.md
+++ b/docs/recipes/adding-a-new-label.md
@@ -1,5 +1,88 @@
 # Recipe: Adding a New Label to the Automation
 
-<!-- TODO: Explain how to add a new GitHub label with color and description to the automation in scripts/createDailyIssue.ts. -->
+The daily issue bot (`scripts/createDailyIssue.ts`) doesn't just create issues — it also makes sure every label it needs actually exists on the repo before it applies them. That logic lives in a function called `ensureLabels`. If you want the bot to use a label that doesn't exist yet, this is where you add it.
 
-This recipe is a stub. Contributors are welcome to fill this in.
+## How the bot manages labels
+
+Inside `scripts/createDailyIssue.ts`, `ensureLabels` keeps two lookup tables: one mapping each label name to a color, and one mapping it to a description.
+
+```ts
+const labelColors: Record<string, string> = {
+  "daily starter issue": "5319e7",
+  documentation: "0075ca",
+  "good first issue": "7057ff",
+  // ...more labels
+};
+
+const labelDescriptions: Record<string, string> = {
+  "daily starter issue": "Generated from the curated daily issue backlog",
+  documentation: "Docs, examples, or wording",
+  "good first issue": "Small task for new contributors",
+  // ...more labels
+};
+```
+
+For every label a daily issue needs, the bot checks whether it already exists on the repo (a `GET` to `/repos/{owner}/{repo}/labels/{label}`). If GitHub returns a 404, it creates the label with a `POST` request using the color and description from those two tables:
+
+```ts
+if (response.status === 404) {
+  await githubRequest(`/repos/${owner}/${repo}/labels`, token, {
+    method: "POST",
+    body: JSON.stringify({
+      name: label,
+      color,
+      description: labelDescriptions[label]
+    })
+  });
+}
+```
+
+If a label with that name already exists, the bot leaves it alone — it does **not** overwrite the color or description of an existing label.
+
+## Adding a new label, step by step
+
+Say you want to add a new label called `skill: writing` in bright yellow, for issues about writing prose or documentation copy.
+
+1. **Open `scripts/createDailyIssue.ts`** and find the `labelColors` object inside `ensureLabels`.
+
+1. **Add your label's name and color** (6-digit hex, no `#`):
+
+```ts
+   const labelColors: Record<string, string> = {
+     // ...existing labels
+     "skill: writing": "fbca04"
+   };
+```
+
+1. **Add a matching entry to `labelDescriptions`**, right below it in the same function:
+
+```ts
+   const labelDescriptions: Record<string, string> = {
+     // ...existing descriptions
+     "skill: writing": "Tasks focused on writing clear prose, copy, or explanations"
+   };
+```
+
+1. **Reference the label** wherever a `DailyIssue` needs it — typically in `src/dailyIssueBacklog.ts`, in that issue's `labels` array. The bot only creates labels that show up in an issue's `labels` list, so adding the color/description alone won't make the label appear on GitHub.
+
+1. **Run the check:**
+
+```bash
+   npm run check
+```
+
+   This confirms the build, tests, and CLI demo all still pass.
+
+1. **Verify it end-to-end (optional but useful):** run the bot in dry-run mode to see the issue body it would generate without hitting the GitHub API:
+
+```bash
+   npm run build
+   node dist/scripts/createDailyIssue.js --dry-run
+```
+
+## Common mistakes
+
+- **Adding the color/description but forgetting to add the label to an issue's `labels` array.** The bot only calls `ensureLabels` with the labels a given `DailyIssue` actually lists — an entry sitting unused in `labelColors` never gets created on GitHub.
+- **Including the `#` in the color value.** GitHub's API expects a bare 6-digit hex string like `fbca04`, not `#fbca04`.
+- **Reusing an existing label name with a different color.** Since the bot skips labels that already exist (it only acts on a 404), changing the color here won't update it on GitHub — you'd need to edit the label manually in the repo settings.
+- **Typos between the two tables.** `labelColors` and `labelDescriptions` are matched by the exact label name string. A mismatched key means the label gets created with no description.

--- a/docs/recipes/handling-github-api-errors.md
+++ b/docs/recipes/handling-github-api-errors.md
@@ -1,5 +1,97 @@
 # Recipe: Handling GitHub API Errors Gracefully
 
-<!-- TODO: Explain common GitHub API error responses this repo's scripts might hit, and how to handle them without crashing the workflow. -->
+Any script in this repo that talks to GitHub (`scripts/createDailyIssue.ts` is the main one) can hit a failed API call — a bad token, a missing repo, a rate limit, whatever. This recipe covers the error responses you're most likely to run into here, and how the repo currently handles (and doesn't handle) them.
 
-This recipe is a stub. Contributors are welcome to fill this in.
+## How this repo currently handles errors
+
+The core piece is the `githubRequest` helper in `scripts/createDailyIssue.ts`. Every API call in the script goes through it:
+
+```ts
+async function githubRequest<T>(
+  path: string,
+  token: string,
+  options: RequestInit = {}
+): Promise<T> {
+  const response = await fetch(`${apiBase}${path}`, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...options.headers
+    }
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`GitHub API failed ${response.status}: ${text}`);
+  }
+
+  return (await response.json()) as T;
+}
+```
+
+This is a "fail fast" strategy: if GitHub returns anything other than a 2xx status, it throws immediately with the status code and the raw response body. At the top level, `main()` catches that and exits with a non-zero code:
+
+```ts
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});
+```
+
+That's deliberate for a script like this one — it runs in CI, and a half-finished run (like some labels created but not others) is worse than a clean failure with a clear error message in the logs.
+
+There's one place where the script does distinguish between error types instead of failing on everything: `ensureLabels` specifically checks for a 404 before deciding what to do:
+
+```ts
+const response = await fetch(`${apiBase}/repos/${owner}/${repo}/labels/${encodeURIComponent(label)}`, {
+  headers: {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28"
+  }
+});
+
+if (response.status === 404) {
+  // label doesn't exist yet — create it
+  await githubRequest(`/repos/${owner}/${repo}/labels`, token, { ... });
+} else if (!response.ok) {
+  // anything else (401, 403, 500, etc.) is a real problem — throw
+  const text = await response.text();
+  throw new Error(`Could not inspect label ${label}: ${text}`);
+}
+```
+
+Here, a 404 isn't an error at all — it's expected and meaningful ("this label doesn't exist yet"). Every other non-2xx status is still treated as a hard failure. That's the pattern to follow if you're adding new API calls: only special-case a status code when it changes what the script should *do*, not just to swallow the error.
+
+## Common error responses you'll actually see
+
+- **401 Unauthorized** — the token is missing, expired, or malformed. In this repo that usually means `GITHUB_TOKEN` wasn't set correctly in the environment.
+- **403 Forbidden** — two very different causes look the same at this status code:
+  - The token doesn't have permission for the action (e.g. missing `issues: write` scope).
+  - You've hit a **rate limit**. Check the response headers `X-RateLimit-Remaining` and `X-RateLimit-Reset` to tell them apart — a permissions problem won't have `X-RateLimit-Remaining: 0`.
+- **404 Not Found** — either the resource genuinely doesn't exist (like a label, handled above) or, confusingly, GitHub also returns 404 for some resources the token doesn't have access to at all, instead of a 403. Don't assume 404 always means "safe to create."
+- **422 Unprocessable Entity** — the request was authenticated and reached the right endpoint, but the payload was invalid (e.g. creating a label with a name that's too long, or duplicate content). The response body usually explains exactly which field failed — `githubRequest`'s `text` capture is what surfaces that to you in the console.
+- **5xx errors** — GitHub's own outage or hiccup. These are usually worth retrying after a short delay rather than failing immediately, though the current script doesn't implement retries.
+
+## If you need to add retry-safe handling
+
+The current script doesn't retry anything — a transient 500 kills the whole run. If you're extending `githubRequest` or writing a new script that needs to survive a flaky GitHub API, a practical approach is to only retry on 5xx and 403-with-rate-limit-headers, and never retry on 401/403 permission errors or 422 validation errors, since retrying those just wastes time on something that won't fix itself:
+
+```ts
+if (response.status >= 500 || (response.status === 403 && response.headers.get("x-ratelimit-remaining") === "0")) {
+  // safe to retry after a delay
+} else if (!response.ok) {
+  // permission or validation problem — don't retry, fail with the real reason
+  throw new Error(`GitHub API failed ${response.status}: ${await response.text()}`);
+}
+```
+
+## Common mistakes
+
+- **Swallowing errors silently.** Catching an error and just logging it without re-throwing or exiting hides real failures from CI — the daily issue bot could silently create zero issues and no one would notice.
+- **Treating every non-2xx status the same way.** As shown in `ensureLabels`, a 404 can mean "does not exist yet" rather than "something is broken" — check the context before deciding an error is fatal.
+- **Not capturing the response body.** The status code alone (like `403`) often isn't enough to debug the problem. `githubRequest`'s `await response.text()` on failure is what makes the actual GitHub error message visible in the logs.
+- **Assuming rate limits only happen under heavy use.** GitHub's API rate limits are lower than people expect, especially for unauthenticated or narrowly-scoped tokens — it's worth checking rate limit headers even on a script that "shouldn't" be making many calls.


### PR DESCRIPTION
## What changed?
- Filled in the `docs/recipes/handling-github-api-errors.md` stub with a full, practical guide.
- Explained how `githubRequest` in `scripts/createDailyIssue.ts` currently handles failed API calls (fail-fast, throw with status + response body).
- Walked through the real `ensureLabels` 404-check pattern as a concrete example of treating one status code differently from the rest.
- Listed the common GitHub API error responses this repo's scripts are likely to hit (401, 403 incl. rate limits, 404, 422, 5xx) and how to tell them apart.
- Added a short section on adding retry-safe handling for future scripts, plus a "Common mistakes" list.
- Confirmed the recipe is already linked from `docs/recipes/README.md`, so no changes were needed there.

## Why does this help?
- The recipe was previously just a TODO stub with no real content.
- Contributors adding new GitHub API calls to this repo now have a clear reference for which errors matter, which don't, and how the existing code already handles them — grounded in the actual script instead of generic API error theory.

## Testing
- [x] I ran `npm run check`

​```
> open-source-starter-lab@0.1.0 check
> npm run build && npm test && npm run demo && npm run site:check-links

> open-source-starter-lab@0.1.0 build
> tsc -p tsconfig.json

> open-source-starter-lab@0.1.0 test
> npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js

Smoke tests passed.
CLI test passed.

> open-source-starter-lab@0.1.0 demo
Readiness score: 76/100

> open-source-starter-lab@0.1.0 site:check-links
Site link check passed.
​```

All checks passed: build succeeded, smoke tests passed, CLI test passed, demo ran, and the site link check passed with no broken links.

## Related issue
Closes #258
<img width="713" height="667" alt="Screenshot 2026-09-05 212018" src="https://github.com/user-attachments/assets/506e57b8-933c-4c94-9c38-964af2a61e87" />
<img width="638" height="321" alt="Screenshot 2026-09-05 212045" src="https://github.com/user-attachments/assets/40454321-1746-4932-a3c9-a8b8786d0bc8" />
