### PR TITLE
test: cover issue fit finder behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pr:welcome": "npm run build && node dist/scripts/welcomePullRequest.js",
     "pr:welcome:dry-run": "npm run build && node dist/scripts/welcomePullRequest.js --dry-run",
     "automation:health": "npm run build && node dist/scripts/createDailyIssue.js --dry-run && node dist/scripts/createWeeklyHelpDiscussion.js --dry-run && node dist/scripts/replyToAssignmentRequest.js --dry-run && node dist/scripts/welcomePullRequest.js --dry-run && node dist/scripts/afterMergeContributorProof.js --dry-run && node dist/scripts/generateMaintainerDashboard.js --dry-run",
-    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js",
+    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js && node dist/tests/issueFitFinder.test.js",
     "check": "npm run build && npm test && npm run demo && npm run site:check-links"
   },
   "keywords": [

--- a/tests/issueFitFinder.test.ts
+++ b/tests/issueFitFinder.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { findIssueFit } from "../src/issueFitFinder.js";
+
+const docsFit = findIssueFit("docs", "30m");
+assert.equal(docsFit.skill, "docs");
+assert.equal(docsFit.timeBudget, "30m");
+assert.equal(docsFit.firstCommand, "npm run check");
+assert.ok(docsFit.issueSearchUrl.startsWith("https://github.com/P-r-e-m-i-u-m/open-source-starter-lab"));
+assert.ok(docsFit.issueSearchUrl.includes("label%3A%22skill%3A%20docs%22"));
+assert.ok(docsFit.issueSearchUrl.includes("no%3Aassignee"));
+assert.ok(docsFit.commentTemplate.includes("Please assign this to me"));
+
+const javascriptFit = findIssueFit(" ts ", "hour");
+assert.equal(javascriptFit.skill, "javascript");
+assert.equal(javascriptFit.timeBudget, "1h");
+assert.ok(javascriptFit.proofChecklist.some((item) => item.includes("full project check")));
+
+assert.throws(() => findIssueFit("unknown"), /Use --skill/);
+assert.throws(() => findIssueFit("docs", "2h"), /Use --time/);
+
+const firstTestingFit = findIssueFit("testing", "15m");
+firstTestingFit.proofChecklist.push("mutated by caller");
+const secondTestingFit = findIssueFit("testing", "15m");
+assert.ok(!secondTestingFit.proofChecklist.includes("mutated by caller"));
+
+console.log("Issue fit finder tests passed.");

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { buildChecklist } from "../src/checklist.js";
-import { findIssueFit } from "../src/issueFitFinder.js";
 import { issueIdeas } from "../src/issueIdeas.js";
 import { dailyIssueBacklog } from "../src/dailyIssueBacklog.js";
 import { chooseIssueCandidates, selectFreshDailyIssues, type ExistingIssue } from "../src/dailyIssueSelection.js";
@@ -48,20 +47,6 @@ assert.ok(
 );
 assert.equal(new Set(dailyIssueBacklog.map((issue) => issue.title)).size, dailyIssueBacklog.length);
 assert.ok(dailyIssueBacklog.every((issue) => scoreDailyIssue(issue).score >= 80));
-
-const docsFit = findIssueFit("docs", "30m");
-assert.equal(docsFit.skill, "docs");
-assert.equal(docsFit.timeBudget, "30m");
-assert.ok(docsFit.issueSearchUrl.includes("no%3Aassignee"));
-assert.ok(docsFit.commentTemplate.includes("Please assign this to me"));
-
-// Test that the issue search URL is actionable
-assert.ok(docsFit.issueSearchUrl.startsWith("https://github.com"));
-assert.ok(docsFit.issueSearchUrl.includes("is%3Aopen")); // URL-encoded
-
-const jsFit = findIssueFit("ts", "1h");
-assert.equal(jsFit.skill, "javascript");
-assert.ok(jsFit.proofChecklist.some((item) => item.includes("full project check")));
 
 const progressionSteps = listProgressionSteps();
 assert.equal(progressionSteps.length, 5);


### PR DESCRIPTION
## What changed?

- Moved issue-fit assertions into a dedicated test and covered aliases, validation, URL construction, and result isolation.

## Why does this help?

- Regressions now fail in a focused test instead of being buried in the broad smoke suite.

## Testing

- [x] I ran `npm run check`

AI helped draft the tests; I reviewed them and ran the full check.

## Related issue

Closes #267
