### PR TITLE
docs: add discussion-to-issue guidance

### DIFF
--- a/docs/MAINTAINER_PLAYBOOK.md
+++ b/docs/MAINTAINER_PLAYBOOK.md
@@ -10,6 +10,18 @@ Strong issues include:
 - Acceptance criteria
 - Expected test command
 - Difficulty label
+### Ready-Issue Checklist
+
+Before marking an issue as ready for contributors, ensure it includes the following:
+
+- [ ] **Context:** Explains why this issue matters and provides necessary background.
+- [ ] **Focused Goal:** Defines a single, achievable outcome.
+- [ ] **Suggested Files:** Points contributors toward the files they will likely need to modify.
+- [ ] **Acceptance Criteria:** Clearly describes the required end result.
+- [ ] **Verification:** Explains how contributors can prove their work is complete.
+- [ ] **Labels Applied:**
+  - [ ] `needs triage` (to flag for maintainer review)
+  - [ ] A relevant `skill: ...` label (e.g., `skill: docs` for documentation tasks)
 
 ## Decode Good First Issues
 

--- a/docs/MAINTAINER_PLAYBOOK.md
+++ b/docs/MAINTAINER_PLAYBOOK.md
@@ -23,6 +23,30 @@ Before marking an issue as ready for contributors, ensure it includes the follow
   - [ ] `needs triage` (to flag for maintainer review)
   - [ ] A relevant `skill: ...` label (e.g., `skill: docs` for documentation tasks)
 
+### Worked Example: From Discussion to Ready Issue
+
+**Before: Discussion comment**
+
+> The Windows setup guide skips the PowerShell command for checking Node.js. Adding it would save new contributors time.
+
+**After: Ready issue**
+
+**Context**
+- Source: Discussion #44.
+- Windows contributors need a clear way to confirm that Node.js is available.
+
+**Goal**
+- Add the missing verification step to the Windows setup guide.
+
+**Acceptance criteria**
+- Document the Node.js verification command in the Windows section.
+- Keep the change focused on the setup guide.
+- Confirm the repository check passes.
+
+**Labels**
+- `needs triage`
+- `skill: docs`
+
 ## Decode Good First Issues
 
 Before publishing a beginner issue, make sure a new contributor can answer:

--- a/docs/WEEKLY_HELP_THREAD.md
+++ b/docs/WEEKLY_HELP_THREAD.md
@@ -17,6 +17,19 @@ I have time for: 15 min / 30 min / 1 hour
 I am stuck on:
 ```
 
+### Transitioning Discussions to Issues
+
+When a GitHub Discussion surfaces a clear problem or feature request that needs action, a maintainer should transition it into a formal, structured issue. To ensure the context isn't lost, the new issue must capture the following details:
+
+* **Source Link:** A direct link to the original discussion thread for historical reference.
+* **Problem Statement:** A clear, concise description of the bug, gap, or feature request.
+* **Relevant Context:** Background information, system environments, or specific user constraints.
+* **Desired Outcome:** A definition of success showing what the completed task looks like.
+* **Evidence and Examples:** Any diagnostic logs, code snippets, or screenshots provided in the thread.
+
+* **Next Step:** A list of actionable tasks or steps to resolve the issue, including any dependencies or prerequisites.
+
+
 ## Maintainer Reply Style
 
 Reply with one focused path:


### PR DESCRIPTION
## What changed?

- Added a structured **Transitioning Discussions to Issues** section inside `docs/WEEKLY_HELP_THREAD.md` to guide maintainers on capturing critical details (Source Link, Problem Statement, Context, Desired Outcome, and Evidence/Examples).
- Created a comprehensive **Ready-Issue Checklist** in `docs/MAINTAINER_PLAYBOOK.md` detailing exact criteria (such as applying labels like `needs triage` and `skill: docs`) required before exposing tasks to contributors.

## Why does this help?

- Standardizes our documentation handover process, preventing critical user context from being lost when moving conversations from GitHub Discussions into scoped development tasks.
- Helps keep the repository clean and welcoming for new open-source contributors with structured, actionable templates.

## Testing

- [x] I ran `npm run check`

## Related issue

Closes #113
