### PR TITLE
test: add coverage for repo issue ideas

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pr:welcome": "npm run build && node dist/scripts/welcomePullRequest.js",
     "pr:welcome:dry-run": "npm run build && node dist/scripts/welcomePullRequest.js --dry-run",
     "automation:health": "npm run build && node dist/scripts/createDailyIssue.js --dry-run && node dist/scripts/createWeeklyHelpDiscussion.js --dry-run && node dist/scripts/replyToAssignmentRequest.js --dry-run && node dist/scripts/welcomePullRequest.js --dry-run && node dist/scripts/afterMergeContributorProof.js --dry-run && node dist/scripts/generateMaintainerDashboard.js --dry-run",
-    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js && node dist/tests/issueFitFinder.test.js && node dist/tests/issueQuality.test.js",
+    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js && node dist/tests/issueFitFinder.test.js && node dist/tests/issueQuality.test.js && node dist/tests/findRepoIssueIdeas.test.js",
     "check": "npm run build && npm test && npm run demo && npm run site:check-links"
   },
   "keywords": [

--- a/tests/findRepoIssueIdeas.test.ts
+++ b/tests/findRepoIssueIdeas.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { findRepoIssueIdeas } from "../scripts/findRepoIssueIdeas.js";
+
+const issues = findRepoIssueIdeas();
+
+assert.ok(Array.isArray(issues));
+assert.ok(issues.length > 0);
+assert.ok(issues.length <= 9);
+
+for (const issue of issues) {
+  assert.ok(typeof issue.title === "string");
+  assert.ok(issue.title.length > 0);
+
+  assert.ok(Array.isArray(issue.labels));
+  assert.ok(issue.labels.includes("help wanted"));
+
+  assert.ok(typeof issue.context === "string");
+  assert.ok(issue.context.length > 0);
+
+  assert.ok(typeof issue.goal === "string");
+  assert.ok(issue.goal.length > 0);
+
+  assert.ok(Array.isArray(issue.suggestedFiles));
+  assert.ok(issue.suggestedFiles.length > 0);
+
+  assert.ok(Array.isArray(issue.acceptanceCriteria));
+  assert.ok(issue.acceptanceCriteria.length > 0);
+}
+
+// Passing the paths of all discovered issues as existing titles
+// should prevent those issues from being suggested again.
+const existingTitles = issues.flatMap((issue) => issue.suggestedFiles);
+
+const filteredIssues = findRepoIssueIdeas(existingTitles);
+
+assert.ok(
+  filteredIssues.length < issues.length,
+  "Known issue paths should be filtered out"
+);
+
+console.log("Find repo issue ideas tests passed.");


### PR DESCRIPTION
## Summary

Adds focused test coverage for `findRepoIssueIdeas`.

## Testing

- Added `tests/findRepoIssueIdeas.test.ts`
- Covers the structure and required fields of generated issue ideas
- Verifies that known issue paths are filtered from future suggestions
- Added the new test to the `npm test` command

## Validation

- `npm run check` ✅
  - Build passed
  - All tests passed
  - Demo passed
  - Site link check passed

Closes #275 
