### PR TITLE
docs: link commit message guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -13,3 +13,6 @@ When your PR is ready, we'll use the **"Squash and merge"** button.
 - Force-pushing or fixing typos
 
 We only care about the final PR. For a detailed explanation, see [Merge Strategy](docs/MERGE_STRATEGY.md).
+
+
+For commit message conventions, see [Commit Message Guide](docs/COMMIT_MESSAGE_GUIDE.md).


### PR DESCRIPTION
## What changed?

-Added a link to the Commit Message Guide in `CONTRIBUTING.md`.

## Why does this help?

-Makes the commit message convention easier for contributors to find.

## Testing

- - [x] Ran `git diff --check`
- [x] Ran `npm run check` successfully

## Related issue

Closes #295
