### PR TITLE
docs: warn against destructive reset on rejected push

### DIFF
--- a/docs/GIT_PUSH_REJECTED.md
+++ b/docs/GIT_PUSH_REJECTED.md
@@ -17,6 +17,8 @@ This usually happens because the remote branch contains commits that are not in 
 
 Do not start by forcing the push. Run these commands one at a time:
 
+Do not use destructive reset commands such as `git reset --hard` blindly, because they can discard local work you still need.
+
 ```bash
 git status
 git remote -v


### PR DESCRIPTION
## What changed?

Added a beginner-friendly warning to `docs/GIT_PUSH_REJECTED.md` about avoiding destructive reset commands such as `git reset --hard` without understanding their impact.

## Why does this help?

This helps contributors avoid accidentally discarding local work when recovering from a rejected Git push.

## Testing

- [x] `npm run check`
- [x] `git diff --check`

## Related issue

Closes #296