### PR TITLE
test: cobertura de dailyIssueBacklog

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pr:welcome": "npm run build && node dist/scripts/welcomePullRequest.js",
     "pr:welcome:dry-run": "npm run build && node dist/scripts/welcomePullRequest.js --dry-run",
     "automation:health": "npm run build && node dist/scripts/createDailyIssue.js --dry-run && node dist/scripts/createWeeklyHelpDiscussion.js --dry-run && node dist/scripts/replyToAssignmentRequest.js --dry-run && node dist/scripts/welcomePullRequest.js --dry-run && node dist/scripts/afterMergeContributorProof.js --dry-run && node dist/scripts/generateMaintainerDashboard.js --dry-run",
-    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js && node dist/tests/issueFitFinder.test.js && node dist/tests/issueQuality.test.js && node dist/tests/findRepoIssueIdeas.test.js && node dist/tests/dailyIssueSelection.test.js && node dist/tests/progressionPath.test.js",
+    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js && node dist/tests/issueFitFinder.test.js && node dist/tests/issueQuality.test.js && node dist/tests/findRepoIssueIdeas.test.js && node dist/tests/dailyIssueSelection.test.js && node dist/tests/progressionPath.test.js && node dist/tests/dailyIssueBacklog.test.js",
     "check": "npm run build && npm test && npm run demo && npm run site:check-links"
   },
   "keywords": [

--- a/tests/dailyIssueBacklog.test.ts
+++ b/tests/dailyIssueBacklog.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { dailyIssueBacklog, type DailyIssue } from "../src/dailyIssueBacklog.js";
+
+// The backlog is a static curated list: no network or API calls here,
+// only structural checks so regressions in shape or content get caught.
+assert.ok(Array.isArray(dailyIssueBacklog), "backlog should be an array");
+assert.ok(
+  dailyIssueBacklog.length > 0,
+  "backlog should contain at least one issue"
+);
+
+// Every entry must carry the shared label so the daily issue bot
+// picks it up as a starter issue.
+for (const issue of dailyIssueBacklog) {
+  assert.ok(
+    issue.labels.includes("daily starter issue"),
+    `"${issue.title}" should be labeled "daily starter issue"`
+  );
+}
+
+// Titles must be unique so duplicate detection in dailyIssueSelection
+// can tell backlog items apart.
+const titles = dailyIssueBacklog.map((issue) => issue.title);
+assert.equal(
+  new Set(titles).size,
+  titles.length,
+  "backlog titles should be unique"
+);
+
+function assertNonEmptyString(value: unknown, context: string): void {
+  assert.equal(typeof value, "string", `${context} should be a string`);
+  assert.ok(
+    (value as string).trim().length > 0,
+    `${context} should not be blank`
+  );
+}
+
+function assertNonEmptyStringArray(
+  value: unknown,
+  context: string
+): void {
+  assert.ok(Array.isArray(value), `${context} should be an array`);
+  assert.ok(
+    (value as unknown[]).length > 0,
+    `${context} should not be empty`
+  );
+  for (const entry of value as unknown[]) {
+    assertNonEmptyString(entry, `${context} entry`);
+  }
+}
+
+// Every entry must satisfy the DailyIssue shape with usable content.
+function assertIssueShape(issue: DailyIssue): void {
+  assertNonEmptyString(issue.title, "title");
+  assertNonEmptyString(issue.context, `context for "${issue.title}"`);
+  assertNonEmptyString(issue.goal, `goal for "${issue.title}"`);
+  assertNonEmptyStringArray(issue.labels, `labels for "${issue.title}"`);
+  assertNonEmptyStringArray(
+    issue.suggestedFiles,
+    `suggestedFiles for "${issue.title}"`
+  );
+  assertNonEmptyStringArray(
+    issue.acceptanceCriteria,
+    `acceptanceCriteria for "${issue.title}"`
+  );
+  assertNonEmptyStringArray(
+    issue.helpfulNotes,
+    `helpfulNotes for "${issue.title}"`
+  );
+}
+
+for (const issue of dailyIssueBacklog) {
+  assertIssueShape(issue);
+}
+
+console.log("Daily issue backlog tests passed.");


### PR DESCRIPTION
## Resumo

Adiciona `tests/dailyIssueBacklog.test.ts` cobrindo o comportamento exportado de `src/dailyIssueBacklog.ts` (o módulo exporta o array `dailyIssueBacklog` + o tipo `DailyIssue`, sem funções — o teste cobre os dados exportados):

- backlog é um array não vazio;
- toda entrada tem o label `daily starter issue`;
- títulos únicos;
- forma de cada entrada: `title`/`context`/`goal` não vazios e arrays não vazios de strings não vazias em `labels`, `suggestedFiles`, `acceptanceCriteria`, `helpfulNotes`.

Também registra o novo teste no script `test` do `package.json`, mantendo todas as entradas existentes.

## Testes / verificação

- `npm test`: todos os testes passam, incluindo o novo (`Daily issue backlog tests passed.`).
- `npm run check`: passa (build + testes + demo + site:check-links).
- Teste independente de rede/API: só asserts sobre dados estáticos.

Closes #235