### PR TITLE
feat: implement leaderboard command for top 5 contributors by merged PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pr:welcome": "npm run build && node dist/scripts/welcomePullRequest.js",
     "pr:welcome:dry-run": "npm run build && node dist/scripts/welcomePullRequest.js --dry-run",
     "automation:health": "npm run build && node dist/scripts/createDailyIssue.js --dry-run && node dist/scripts/createWeeklyHelpDiscussion.js --dry-run && node dist/scripts/replyToAssignmentRequest.js --dry-run && node dist/scripts/welcomePullRequest.js --dry-run && node dist/scripts/afterMergeContributorProof.js --dry-run && node dist/scripts/generateMaintainerDashboard.js --dry-run",
-    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js && node dist/tests/issueFitFinder.test.js && node dist/tests/issueQuality.test.js && node dist/tests/findRepoIssueIdeas.test.js && node dist/tests/dailyIssueSelection.test.js && node dist/tests/progressionPath.test.js && node dist/tests/dailyIssueBacklog.test.js",
+    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js && node dist/tests/issueFitFinder.test.js && node dist/tests/issueQuality.test.js && node dist/tests/findRepoIssueIdeas.test.js && node dist/tests/dailyIssueSelection.test.js && node dist/tests/progressionPath.test.js && node dist/tests/dailyIssueBacklog.test.js && node dist/tests/leaderboard.test.js",
     "check": "npm run build && npm test && npm run demo && npm run site:check-links"
   },
   "keywords": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { buildChecklist, PROFILE_DESCRIPTIONS, type StarterProfile } from "./che
 import { findIssueFit } from "./issueFitFinder.js";
 import { issueIdeas } from "./issueIdeas.js";
 import { getProgressionStep, normalizeContributorLevel } from "./progressionPath.js";
+import { leaderboard } from "./plugins/leaderboard.js";
 
 function readFlag(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -145,6 +146,11 @@ function main(): void {
     return;
   }  
 
+  if (command === "leaderboard") {
+    leaderboard();
+    return;
+  }
+
   if (command === "help" || command === "--help" || command === "-h") {
     console.log("Usage:");
     console.log("  oss-lab check --profile beginner");
@@ -156,6 +162,7 @@ function main(): void {
     console.log("    Skills: html-css, javascript, python, docs, testing, git");
     console.log("    Time: 15m, 30m, 1h");
     console.log("  oss-lab next --level second-pr");
+    console.log("  oss-lab leaderboard");
     return;
   }
 

--- a/src/plugins/leaderboard.ts
+++ b/src/plugins/leaderboard.ts
@@ -1,4 +1,98 @@
-// TODO: Implement a command that shows the top five contributors by merged PRs in the last 30 days.
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface MergedPullRequest {
+  username: string;
+  mergedAt: Date;
+}
+
+export interface ContributorRank {
+  username: string;
+  mergedPullRequests: number;
+}
+
+const PASSPORTS_DIR = join("contributors", "passports");
+const WINDOW_DAYS = 30;
+const TOP_N = 5;
+
+function parsePassportFile(fileName: string, contents: string): MergedPullRequest[] {
+  const username = fileName.replace(/\.md$/, "");
+  const rows: MergedPullRequest[] = [];
+
+  for (const line of contents.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("| #")) continue;
+
+    const cells = trimmed
+      .split("|")
+      .map((cell) => cell.trim())
+      .filter((cell) => cell.length > 0);
+
+    const dateText = cells[1];
+    if (!dateText) continue;
+
+    const mergedAt = new Date(dateText);
+    if (Number.isNaN(mergedAt.getTime())) continue;
+
+    rows.push({ username, mergedAt });
+  }
+
+  return rows;
+}
+
+function loadMergedPullRequests(): MergedPullRequest[] {
+  let fileNames: string[];
+  try {
+    fileNames = readdirSync(PASSPORTS_DIR);
+  } catch {
+    return [];
+  }
+
+  const merged: MergedPullRequest[] = [];
+  for (const fileName of fileNames) {
+    if (!fileName.endsWith(".md") || fileName.toLowerCase() === "readme.md") continue;
+    const contents = readFileSync(join(PASSPORTS_DIR, fileName), "utf8");
+    merged.push(...parsePassportFile(fileName, contents));
+  }
+
+  return merged;
+}
+
+export function topContributorsByMergedPRs(
+  mergedPullRequests: MergedPullRequest[],
+  referenceDate: Date = new Date(),
+  windowDays: number = WINDOW_DAYS,
+  limit: number = TOP_N
+): ContributorRank[] {
+  const cutoff = new Date(referenceDate);
+  cutoff.setDate(cutoff.getDate() - windowDays);
+
+  const counts = new Map<string, number>();
+  for (const pr of mergedPullRequests) {
+    if (pr.mergedAt >= cutoff && pr.mergedAt <= referenceDate) {
+      counts.set(pr.username, (counts.get(pr.username) ?? 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .map(([username, mergedPullRequests]) => ({ username, mergedPullRequests }))
+    .sort((a, b) => b.mergedPullRequests - a.mergedPullRequests || a.username.localeCompare(b.username))
+    .slice(0, limit);
+}
+
 export function leaderboard(): void {
-  console.log("Not implemented yet.");
+  const mergedPullRequests = loadMergedPullRequests();
+  const top = topContributorsByMergedPRs(mergedPullRequests);
+
+  console.log(`Top ${TOP_N} contributors by merged PRs in the last ${WINDOW_DAYS} days\n`);
+
+  if (top.length === 0) {
+    console.log("No merged pull requests recorded in the last 30 days.");
+    return;
+  }
+
+  top.forEach((contributor, index) => {
+    const label = contributor.mergedPullRequests === 1 ? "merged PR" : "merged PRs";
+    console.log(`${index + 1}. ${contributor.username} - ${contributor.mergedPullRequests} ${label}`);
+  });
 }

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { topContributorsByMergedPRs, type MergedPullRequest } from "../src/plugins/leaderboard.js";
+
+const referenceDate = new Date("2026-09-12");
+
+const sample: MergedPullRequest[] = [
+  { username: "alice", mergedAt: new Date("2026-09-01") },
+  { username: "alice", mergedAt: new Date("2026-09-05") },
+  { username: "alice", mergedAt: new Date("2026-09-10") },
+  { username: "bob", mergedAt: new Date("2026-09-08") },
+  { username: "bob", mergedAt: new Date("2026-09-09") },
+  { username: "carol", mergedAt: new Date("2026-09-11") },
+  // Outside the 30-day window from the reference date, should not be counted.
+  { username: "dave", mergedAt: new Date("2026-06-01") }
+];
+
+const result = topContributorsByMergedPRs(sample, referenceDate);
+
+assert.equal(result.length, 3);
+assert.deepEqual(result[0], { username: "alice", mergedPullRequests: 3 });
+assert.deepEqual(result[1], { username: "bob", mergedPullRequests: 2 });
+assert.deepEqual(result[2], { username: "carol", mergedPullRequests: 1 });
+assert.ok(!result.some((entry) => entry.username === "dave"));
+
+// Respects a custom limit.
+const top1 = topContributorsByMergedPRs(sample, referenceDate, 30, 1);
+assert.equal(top1.length, 1);
+assert.equal(top1[0].username, "alice");
+
+// Ties are broken alphabetically by username.
+const tied: MergedPullRequest[] = [
+  { username: "zed", mergedAt: new Date("2026-09-05") },
+  { username: "amy", mergedAt: new Date("2026-09-05") }
+];
+const tiedResult = topContributorsByMergedPRs(tied, referenceDate);
+assert.equal(tiedResult[0].username, "amy");
+assert.equal(tiedResult[1].username, "zed");
+
+// A PR merged exactly on the cutoff boundary should still count.
+const cutoffDate = new Date(referenceDate);
+cutoffDate.setDate(cutoffDate.getDate() - 30);
+const boundary: MergedPullRequest[] = [{ username: "edge", mergedAt: cutoffDate }];
+const boundaryResult = topContributorsByMergedPRs(boundary, referenceDate);
+assert.equal(boundaryResult.length, 1);
+assert.equal(boundaryResult[0].username, "edge");
+
+// No merged PRs in range returns an empty list.
+const empty = topContributorsByMergedPRs([{ username: "old", mergedAt: new Date("2020-01-01") }], referenceDate);
+assert.equal(empty.length, 0);
+
+console.log("leaderboard.test.ts passed");


### PR DESCRIPTION
## What changed?

- Implemented the TODO in `src/plugins/leaderboard.ts`: `leaderboard()` now reads every contributor's merge history from `contributors/passports/*.md`, counts merged PRs per contributor within the last 30 days, and prints the top 5 ranked by count (ties broken alphabetically).
- Wired the new command into `src/cli.ts` as `oss-lab leaderboard`, and added it to the help text.
- Added `tests/leaderboard.test.ts` covering the core ranking logic: basic counts, custom limit, alphabetical tie-break, the 30-day boundary date, and the empty-result case.
- Added `dist/tests/leaderboard.test.js` to the `test` script chain in `package.json` so it runs as part of `npm run check`.

## Why does this help?

- The TODO had been sitting unimplemented; this closes it out with a real, working leaderboard instead of guessing at scope.
- No new dependency or GitHub API call was needed — the repo already tracks merged PR history per contributor in `contributors/passports/`, so the command reads from that existing source of truth.
- The ranking logic is a pure, testable function (`topContributorsByMergedPRs`) separate from file I/O, so it's easy to verify and extend later.

## Testing
<img width="1056" height="738" alt="Screenshot 2026-09-12 145148" src="https://github.com/user-attachments/assets/b85d5c9b-c1ac-4314-a6a3-b3bd46a90e10" />
<img width="997" height="747" alt="Screenshot 2026-09-12 145231" src="https://github.com/user-attachments/assets/8be99833-7ebc-4e4a-b99e-7c5471cca67d" />
<img width="835" height="733" alt="Screenshot 2026-09-12 145252" src="https://github.com/user-attachments/assets/8dbc8c6b-3170-48ad-ab9f-4acd34e483cf" />

- [x] I ran `npm run check`
- Output confirms build, all existing tests, the new `leaderboard.test.ts`, demo, and site link check all pass.
- Manually ran `node dist/src/cli.js leaderboard` and confirmed it prints a real top-5 list from current contributor data.

## Related issue

Closes #320