### PR TITLE
feat: add suggest issue command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "pr:welcome": "npm run build && node dist/scripts/welcomePullRequest.js",
     "pr:welcome:dry-run": "npm run build && node dist/scripts/welcomePullRequest.js --dry-run",
     "automation:health": "npm run build && node dist/scripts/createDailyIssue.js --dry-run && node dist/scripts/createWeeklyHelpDiscussion.js --dry-run && node dist/scripts/replyToAssignmentRequest.js --dry-run && node dist/scripts/welcomePullRequest.js --dry-run && node dist/scripts/afterMergeContributorProof.js --dry-run && node dist/scripts/generateMaintainerDashboard.js --dry-run",
-    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js && node dist/tests/issueFitFinder.test.js && node dist/tests/issueQuality.test.js && node dist/tests/findRepoIssueIdeas.test.js && node dist/tests/dailyIssueSelection.test.js && node dist/tests/progressionPath.test.js && node dist/tests/dailyIssueBacklog.test.js",
+    "test": "npm run build && node dist/tests/smoke.test.js && node dist/tests/cli.test.js && node dist/tests/issueFitFinder.test.js && node dist/tests/issueQuality.test.js && node dist/tests/findRepoIssueIdeas.test.js && node dist/tests/dailyIssueSelection.test.js && node dist/tests/progressionPath.test.js && node dist/tests/dailyIssueBacklog.test.js && node dist/tests/suggest.test.js",
     "check": "npm run build && npm test && npm run demo && npm run site:check-links"
   },
   "keywords": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { buildChecklist, PROFILE_DESCRIPTIONS, type StarterProfile } from "./che
 import { findIssueFit } from "./issueFitFinder.js";
 import { issueIdeas } from "./issueIdeas.js";
 import { getProgressionStep, normalizeContributorLevel } from "./progressionPath.js";
+import { suggest } from "./plugins/suggest.js";
 
 function readFlag(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -145,6 +146,11 @@ function main(): void {
     return;
   }  
 
+  if (command === "suggest") {
+    suggest();
+    return;
+  }
+
   if (command === "help" || command === "--help" || command === "-h") {
     console.log("Usage:");
     console.log("  oss-lab check --profile beginner");
@@ -156,6 +162,7 @@ function main(): void {
     console.log("    Skills: html-css, javascript, python, docs, testing, git");
     console.log("    Time: 15m, 30m, 1h");
     console.log("  oss-lab next --level second-pr");
+    console.log("  oss-lab suggest --skill docs --time 30m");
     return;
   }
 

--- a/src/plugins/suggest.ts
+++ b/src/plugins/suggest.ts
@@ -1,4 +1,51 @@
-// TODO: Implement a command that recommends one open issue based on a skill the user types in, reusing the existing issue-fit logic.
+import { findIssueFit } from "../issueFitFinder.js";
+
+function readFlag(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+/**
+ * Recommends one starter-issue path based on a skill the user provides,
+ * by reusing the existing issue-fit logic in issueFitFinder.ts. This repo
+ * has no live GitHub API integration, so "one open issue" means the best
+ * matching route plus a ready-to-use search link to find an actual open,
+ * unassigned issue for that skill right now.
+ */
 export function suggest(): void {
-  console.log("Not implemented yet.");
+  const skillInput = readFlag("--skill");
+
+  if (!skillInput) {
+    console.log("Tell me a skill to get a suggested issue, for example:");
+    console.log("  oss-lab suggest --skill docs");
+    console.log("  oss-lab suggest --skill javascript --time 30m");
+    console.log("\nAvailable skills: html-css, javascript, python, docs, testing, git");
+    return;
+  }
+
+  const timeInput = readFlag("--time") ?? "30m";
+
+  let fit;
+  try {
+    fit = findIssueFit(skillInput, timeInput);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`Could not suggest an issue: ${message}`);
+    return;
+  }
+
+  console.log("Suggested next issue\n");
+  console.log(`Skill: ${fit.skill}`);
+  console.log(`Best path: ${fit.title}`);
+  console.log(`Why it fits: ${fit.whyItFits}`);
+  console.log(`First command: ${fit.firstCommand}`);
+  console.log(`Time budget: ${fit.timeBudget}`);
+  console.log("\nFind an open issue to work on:");
+  console.log(`→ ${fit.issueSearchUrl}`);
+  console.log("\nProof checklist:");
+  for (const item of fit.proofChecklist) {
+    console.log(`- ${item}`);
+  }
+  console.log("\nComment to paste once you pick one:");
+  console.log(fit.commentTemplate);
 }

--- a/tests/suggest.test.ts
+++ b/tests/suggest.test.ts
@@ -1,0 +1,94 @@
+import { spawnSync } from "node:child_process";
+
+function run(args: string[]) {
+  return spawnSync(process.execPath, ["dist/src/cli.js", ...args], {
+    encoding: "utf8",
+    timeout: 5000
+  });
+}
+
+function testSuggestCommand(): void {
+  console.log("🧪 Running: Suggest command test...");
+
+  const tests = [
+    {
+      name: "no --skill flag prompts for one instead of crashing",
+      args: ["suggest"],
+      check: (result: ReturnType<typeof run>) => {
+        if (result.status !== 0) {
+          throw new Error(`Expected exit code 0, got ${result.status}`);
+        }
+        if (!result.stdout.includes("Tell me a skill")) {
+          throw new Error(`Expected a prompt for a skill. Got: ${result.stdout}`);
+        }
+      }
+    },
+    {
+      name: "valid --skill returns a suggested issue path",
+      args: ["suggest", "--skill", "docs"],
+      check: (result: ReturnType<typeof run>) => {
+        if (result.status !== 0) {
+          throw new Error(`Expected exit code 0, got ${result.status}`);
+        }
+        if (!result.stdout.includes("Suggested next issue")) {
+          throw new Error(`Expected a suggestion header. Got: ${result.stdout}`);
+        }
+        if (!result.stdout.includes("Skill: docs")) {
+          throw new Error(`Expected the resolved skill in output. Got: ${result.stdout}`);
+        }
+        if (!result.stdout.includes("Comment to paste")) {
+          throw new Error(`Expected a ready-to-use comment template. Got: ${result.stdout}`);
+        }
+      }
+    },
+    {
+      name: "skill alias resolves the same as canonical skill",
+      args: ["suggest", "--skill", "js"],
+      check: (result: ReturnType<typeof run>) => {
+        if (result.status !== 0) {
+          throw new Error(`Expected exit code 0, got ${result.status}`);
+        }
+        if (!result.stdout.includes("Skill: javascript")) {
+          throw new Error(`Expected alias "js" to resolve to javascript. Got: ${result.stdout}`);
+        }
+      }
+    },
+    {
+      name: "unknown skill fails gracefully without a stack trace",
+      args: ["suggest", "--skill", "cobol"],
+      check: (result: ReturnType<typeof run>) => {
+        if (result.status !== 0) {
+          throw new Error(`Expected exit code 0 (handled error), got ${result.status}`);
+        }
+        if (!result.stdout.includes("Could not suggest an issue")) {
+          throw new Error(`Expected a friendly error message. Got: ${result.stdout}`);
+        }
+      }
+    }
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const test of tests) {
+    try {
+      const result = run(test.args);
+      test.check(result);
+      console.log(`  ✅ ${test.name}`);
+      passed++;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`  ❌ ${test.name}: ${message}`);
+      failed++;
+    }
+  }
+
+  if (failed > 0) {
+    console.error(`\n❌ ${failed} test(s) failed, ${passed} passed`);
+    process.exit(1);
+  }
+
+  console.log(`\n✅ All ${passed} suggest tests passed! 🎉`);
+}
+
+testSuggestCommand();


### PR DESCRIPTION

## What changed?

- Added a new `suggest` CLI command for finding a suitable open-source issue based on a developer's skill.
- Added skill alias support so common skill variations resolve to the same canonical skill.
- Added graceful handling when `--skill` is missing or an unknown skill is provided.
- Added tests covering valid skills, aliases, missing skills, and unknown skills.

## Why does this help?

- Makes it easier for contributors to discover a good first issue based on their existing skills.
- Provides a simpler and more beginner-friendly way to navigate the project's issue recommendations.
- Prevents crashes and gives clear feedback for invalid or missing skill input.

## Testing
<img width="1166" height="745" alt="Screenshot 2026-09-12 151713" src="https://github.com/user-attachments/assets/cc65cbec-d09b-40de-9be3-b010fb14fd92" />
<img width="1152" height="757" alt="Screenshot 2026-09-12 151727" src="https://github.com/user-attachments/assets/17da440f-6a71-47de-879b-9510e5d828de" />
<img width="1150" height="750" alt="Screenshot 2026-09-12 151748" src="https://github.com/user-attachments/assets/21587bde-f63a-4fe1-963a-17b86790ebd3" />

- [x] I ran `npm run check`

## Related issue

Closes #328