### PR TITLE
test: add weekly summary coverage

### DIFF
--- a/tests/weeklySummary.test.ts
+++ b/tests/weeklySummary.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+
+import { weeklySummary } from "../src/plugins/weeklySummary.js";
+
+let output = "";
+
+const originalLog = console.log;
+
+console.log = (message: string) => {
+  output = message;
+};
+
+weeklySummary();
+
+console.log = originalLog;
+
+assert.equal(output, "Not implemented yet.");
+
+console.log("Weekly summary tests passed.");


### PR DESCRIPTION
## What changed
Added focused test coverage for the weeklySummary plugin.

## Why
The weeklySummary plugin had no dedicated test coverage.

## How tested
- npm run build
- node dist/tests/weeklySummary.test.js
- ## Testing

- `npm run check` — passed
- `node dist/tests/weeklySummary.test.js` — passed

Closes #334