### PR TITLE
test: add coverage for timeline plugin

### DIFF
--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -7,6 +7,7 @@ import { dailyIssueBacklog } from "../src/dailyIssueBacklog.js";
 import { chooseIssueCandidates, selectFreshDailyIssues, type ExistingIssue } from "../src/dailyIssueSelection.js";
 import { scoreDailyIssue } from "../src/issueQuality.js";
 import { getProgressionStep, listProgressionSteps, normalizeContributorLevel } from "../src/progressionPath.js";
+import { timeline } from "../src/plugins/timeline.js";
 
 const beginner = buildChecklist("beginner");
 assert.equal(beginner.profile, "beginner");
@@ -223,5 +224,16 @@ const everythingOpen = selectFreshDailyIssues(
 
 assert.equal(everythingOpen.fresh.length, 0);
 assert.equal(everythingOpen.duplicates.length, dailyIssueBacklog.length);
+
+let capturedTimelineOutput = "";
+const originalLog = console.log;
+console.log = (msg: string) => {
+  capturedTimelineOutput = msg;
+};
+
+timeline();
+
+console.log = originalLog;
+assert.equal(capturedTimelineOutput, "Not implemented yet.");
 
 console.log("Smoke tests passed.");


### PR DESCRIPTION
Closes #332

### Summary
Adds focused test coverage for the exported `timeline()` function in `src/plugins/timeline.ts` without making network calls.

### Verification
Ran `npm run check` locally:

```text
Smoke tests passed.
🧪 Running: Unknown command test...
  ✅ unknown command fails with non-zero exit code
  ✅ error message contains "Unknown command"
  ✅ unknown command output is not empty

✅ All 3 tests passed! 🎉
Issue fit finder tests passed.
Issue quality scoring tests passed.
Find repo issue ideas tests passed.
Daily issue selection tests passed.
Progression path tests passed.
Daily issue backlog tests passed.
Site link check passed.
```